### PR TITLE
test: 노드 테스트 공통 fixture 추가

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -190,14 +190,14 @@ PRD 케이스 1·2가 처음부터 끝까지 작동하는 것.
 **담당 파일**: `tests/conftest.py`
 **의존**: T1 (데이터 구조 확정 후) | **블로킹**: T4~T7 테스트 정상 실행
 
-- [ ] 케이스 1 학생 fixture (못함+불성실, 1학년, 국어 태스크)
-- [ ] 케이스 2 학생 fixture (못함+성실, 5학년, 수학 태스크)
-- [ ] 잘함+성실 학생 fixture
-- [ ] 잘함+불성실 학생 fixture
-- [ ] `ChatState` 초기값 생성 헬퍼 함수
-- [ ] `FastAPI TestClient` fixture
-- [ ] Upstage LLM mock fixture (실제 API 호출 차단)
-- [ ] **완료 기준**: T4~T7 테스트 파일에서 fixture import 정상, `uv run pytest` 전체 통과
+- [x] 케이스 1 학생 fixture (못함+불성실, 1학년, 국어 태스크)
+- [x] 케이스 2 학생 fixture (못함+성실, 5학년, 수학 태스크)
+- [x] 잘함+성실 학생 fixture
+- [x] 잘함+불성실 학생 fixture
+- [x] `ChatState` 초기값 생성 헬퍼 함수
+- [x] `FastAPI TestClient` fixture
+- [x] Upstage LLM mock fixture (실제 API 호출 차단)
+- [x] **완료 기준**: T4~T7 테스트 파일에서 fixture import 정상, `uv run pytest` 전체 통과
 
 ---
 

--- a/docs/worklogs/2026-04-28_feature-T8-conftest.md
+++ b/docs/worklogs/2026-04-28_feature-T8-conftest.md
@@ -1,0 +1,25 @@
+# Worklog — feature/T8-conftest
+
+## 작업 배경
+
+T4~T7 노드 테스트를 병렬로 작성할 때 같은 학생 데이터와 `ChatState` 초기값을 반복해서 만들지 않도록 공통 fixture가 필요했다.
+
+## 작업 내용
+
+- `tests/conftest.py` 신규 작성
+  - 케이스 1 fixture: 1학년 국어, `못함+불성실` 시나리오
+  - 케이스 2 fixture: 5학년 수학, `못함+성실` 시나리오
+  - `잘함+성실`, `잘함+불성실` 학생 fixture
+  - `make_chat_state` 헬퍼
+  - FastAPI `TestClient` fixture
+  - 실제 Upstage 호출을 막는 `mock_llm` fixture
+- `TODO.md` T8 체크리스트 완료 반영
+
+## 확인
+
+- `uv run pytest` 통과
+
+## 다음 작업
+
+- T4 classify 노드 테스트에서 `case1_student`, `case2_student`, `make_chat_state` 활용
+- T5~T7 노드 테스트에서 `mock_llm`과 학생 fixture 활용

--- a/docs/worklogs/2026-04-28_feature-T8-conftest.md
+++ b/docs/worklogs/2026-04-28_feature-T8-conftest.md
@@ -3,8 +3,27 @@
 ## 작업 배경
 
 T4~T7 노드 테스트를 병렬로 작성할 때 같은 학생 데이터와 `ChatState` 초기값을 반복해서 만들지 않도록 공통 fixture가 필요했다.
+PRD의 핵심 MVP 케이스 1·2와 나머지 두 세그먼트 학생을 같은 기준으로 재사용할 수 있어야, classify/TP 노드 테스트가 서로 다른 더미 데이터 때문에 흔들리지 않는다.
 
-## 작업 내용
+## 왜 필요한가
+
+- T4 classify는 학생 데이터를 읽어 세그먼트와 학년 그룹을 판별해야 한다.
+- T5~T7 노드는 같은 `ChatState` 구조를 전제로 응답을 만든다.
+- 실제 Upstage API 호출은 테스트에서 차단해야 한다.
+- 여러 팀원이 노드 테스트를 작성해도 학생 fixture와 상태 초기값이 같아야 PRD 기준을 공유할 수 있다.
+
+## 구현 방법
+
+- `tests/conftest.py`에 네 가지 학생 fixture를 정의했다.
+  - 케이스 1: 1학년 국어, 저성취 + 불성실
+  - 케이스 2: 5학년 수학, 저성취 + 성실
+  - 잘함 + 성실
+  - 잘함 + 불성실
+- `make_chat_state` helper를 만들어 테스트가 필요한 `segment`, `grade_group`, `use_case`, `touchpoint`만 바꿔 `ChatState`를 만들 수 있게 했다.
+- FastAPI endpoint 테스트를 위해 `client` fixture를 제공했다.
+- `mock_llm` fixture는 `app.clients.upstage` 모듈을 fake module로 주입해 실제 API 호출을 막는다.
+
+## 변경 내용
 
 - `tests/conftest.py` 신규 작성
   - 케이스 1 fixture: 1학년 국어, `못함+불성실` 시나리오
@@ -15,9 +34,29 @@ T4~T7 노드 테스트를 병렬로 작성할 때 같은 학생 데이터와 `Ch
   - 실제 Upstage 호출을 막는 `mock_llm` fixture
 - `TODO.md` T8 체크리스트 완료 반영
 
+## 주요 변경 파일
+
+- `tests/conftest.py`
+  - `case1_student`, `case2_student`
+  - `high_diligent_student`, `high_lazy_student`
+  - `make_chat_state`
+  - `client`
+  - `mock_llm`
+- `TODO.md`
+  - T8 공통 fixture 항목과 완료 기준 체크
+- `docs/worklogs/2026-04-28_feature-T8-conftest.md`
+  - 작업 배경, 구현 방식, 검증 결과 기록
+
 ## 확인
 
 - `uv run pytest` 통과
+- `git diff --check` 통과
+
+## PR 참고
+
+- PR 대상: `dev`
+- 이 PR은 T4~T7 노드 구현 전 테스트 기반을 만드는 PR이다.
+- T4~T7 브랜치에서 이 fixture를 쓰려면 이 PR이 먼저 머지되어 있거나, 각 브랜치가 이 변경을 포함하도록 최신화되어야 한다.
 
 ## 다음 작업
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.enums import (
+    Difficulty,
+    GradeGroup,
+    Segment,
+    Subject,
+    Touchpoint,
+    UseCase,
+    WrongCause,
+)
+from app.data.loader import StudentRecord
+from app.main import app
+from app.schemas.chat import ChatState, Task
+
+
+@pytest.fixture
+def case1_student() -> StudentRecord:
+    return {
+        "student_id": "case-1-low-lazy-korean",
+        "profile": {
+            "name": "민준",
+            "grade": 1,
+            "preferred_subject": Subject.KOREAN,
+            "strong_subject": Subject.KOREAN,
+            "recent_avg_score": 62,
+            "avg_completion_rate": 35,
+        },
+        "learning_history": {
+            "subject_avg_scores": {Subject.KOREAN.value: 62},
+            "subject_completion_rates": {Subject.KOREAN.value: 35},
+        },
+        "learning_pattern": {
+            "wrong_content_rate": 20,
+            "wrong_content_total": 2,
+            "wrong_content_done": 0,
+            "skipping_habit": True,
+            "guessing_habit": False,
+            "careless_habit": True,
+        },
+        "wrong_answer_pattern": {
+            "frequent_wrong_type": "짧은 글 읽기",
+            "repeated_wrong_subjects": [Subject.KOREAN.value],
+            "wrong_cause": WrongCause.CONCEPT_LACK,
+        },
+        "today_tasks": [
+            {
+                "subject": Subject.KOREAN.value,
+                "unit": "짧은 글 읽기",
+                "problem_count": 3,
+                "estimated_time": 5,
+                "difficulty": Difficulty.LOW.value,
+                "ai_predicted_score": 65,
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def case2_student() -> StudentRecord:
+    return {
+        "student_id": "case-2-low-diligent-math",
+        "profile": {
+            "name": "서연",
+            "grade": 5,
+            "preferred_subject": Subject.MATH,
+            "strong_subject": Subject.SCIENCE,
+            "recent_avg_score": 72,
+            "avg_completion_rate": 88,
+        },
+        "learning_history": {
+            "subject_avg_scores": {Subject.MATH.value: 72},
+            "subject_completion_rates": {Subject.MATH.value: 88},
+        },
+        "learning_pattern": {
+            "wrong_content_rate": 75,
+            "wrong_content_total": 3,
+            "wrong_content_done": 1,
+            "skipping_habit": False,
+            "guessing_habit": False,
+            "careless_habit": False,
+        },
+        "wrong_answer_pattern": {
+            "frequent_wrong_type": "비율과 비례식",
+            "repeated_wrong_subjects": [Subject.MATH.value],
+            "wrong_cause": WrongCause.CONCEPT_LACK,
+        },
+        "today_tasks": [
+            {
+                "subject": Subject.MATH.value,
+                "unit": "비율과 비례식",
+                "problem_count": 4,
+                "estimated_time": 12,
+                "difficulty": Difficulty.MEDIUM.value,
+                "ai_predicted_score": 74,
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def high_diligent_student() -> StudentRecord:
+    return {
+        "student_id": "high-diligent",
+        "profile": {
+            "name": "하윤",
+            "grade": 4,
+            "preferred_subject": Subject.SCIENCE,
+            "strong_subject": Subject.MATH,
+            "recent_avg_score": 95,
+            "avg_completion_rate": 92,
+        },
+        "learning_history": {
+            "subject_avg_scores": {Subject.MATH.value: 95, Subject.SCIENCE.value: 97},
+            "subject_completion_rates": {
+                Subject.MATH.value: 92,
+                Subject.SCIENCE.value: 94,
+            },
+        },
+        "learning_pattern": {
+            "wrong_content_rate": None,
+            "wrong_content_total": 0,
+            "wrong_content_done": 0,
+            "skipping_habit": False,
+            "guessing_habit": False,
+            "careless_habit": False,
+        },
+        "wrong_answer_pattern": {
+            "frequent_wrong_type": "",
+            "repeated_wrong_subjects": [],
+            "wrong_cause": WrongCause.MISTAKE,
+        },
+        "today_tasks": [
+            {
+                "subject": Subject.MATH.value,
+                "unit": "응용 문제",
+                "problem_count": 5,
+                "estimated_time": 10,
+                "difficulty": Difficulty.HIGH.value,
+                "ai_predicted_score": 94,
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def high_lazy_student() -> StudentRecord:
+    return {
+        "student_id": "high-lazy",
+        "profile": {
+            "name": "도윤",
+            "grade": 6,
+            "preferred_subject": Subject.MATH,
+            "strong_subject": Subject.MATH,
+            "recent_avg_score": 93,
+            "avg_completion_rate": 42,
+        },
+        "learning_history": {
+            "subject_avg_scores": {Subject.MATH.value: 93},
+            "subject_completion_rates": {Subject.MATH.value: 42},
+        },
+        "learning_pattern": {
+            "wrong_content_rate": 25,
+            "wrong_content_total": 2,
+            "wrong_content_done": 0,
+            "skipping_habit": True,
+            "guessing_habit": False,
+            "careless_habit": True,
+        },
+        "wrong_answer_pattern": {
+            "frequent_wrong_type": "응용 문제",
+            "repeated_wrong_subjects": [Subject.MATH.value],
+            "wrong_cause": WrongCause.MISTAKE,
+        },
+        "today_tasks": [
+            {
+                "subject": Subject.MATH.value,
+                "unit": "도전 문제",
+                "problem_count": 3,
+                "estimated_time": 7,
+                "difficulty": Difficulty.HIGH.value,
+                "ai_predicted_score": 91,
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def make_chat_state() -> Callable[..., ChatState]:
+    def _make_chat_state(
+        student: StudentRecord,
+        *,
+        segment: Segment,
+        grade_group: GradeGroup,
+        use_case: UseCase = UseCase.TALK,
+        touchpoint: Touchpoint = Touchpoint.TP1,
+        completed_tasks: list[Task] | None = None,
+        current_task: Task | None = None,
+    ) -> ChatState:
+        today_tasks = student["today_tasks"]
+        completed = completed_tasks or []
+        learning_pattern = student["learning_pattern"]
+
+        return {
+            "thread_id": f"thread-{student['student_id']}",
+            "student_id": student["student_id"],
+            "student_profile": student["profile"],
+            "learning_history": student["learning_history"],
+            "learning_pattern": learning_pattern,
+            "wrong_answer_pattern": student["wrong_answer_pattern"],
+            "today_tasks": today_tasks,
+            "completed_tasks": completed,
+            "current_task": current_task or (today_tasks[0] if today_tasks else None),
+            "has_wrong_answers": learning_pattern["wrong_content_total"] > 0,
+            "wrong_content_done_today": (
+                learning_pattern["wrong_content_total"] > 0
+                and learning_pattern["wrong_content_done"]
+                >= learning_pattern["wrong_content_total"]
+            ),
+            "today_score": student["profile"]["recent_avg_score"],
+            "use_case": use_case,
+            "grade_group": grade_group,
+            "segment": segment,
+            "chat_history": [],
+            "current_touchpoint": touchpoint,
+        }
+
+    return _make_chat_state
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@dataclass
+class FakeLLMResponse:
+    content: str
+
+
+@dataclass
+class FakeLLM:
+    response_content: str = "테스트용 AI 코치 응답입니다."
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def invoke(self, messages, **kwargs) -> FakeLLMResponse:
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        return FakeLLMResponse(content=self.response_content)
+
+    async def ainvoke(self, messages, **kwargs) -> FakeLLMResponse:
+        return self.invoke(messages, **kwargs)
+
+    def stream(self, messages, **kwargs):
+        yield self.invoke(messages, **kwargs)
+
+
+@pytest.fixture
+def mock_llm(monkeypatch) -> FakeLLM:
+    fake_llm = FakeLLM()
+    fake_module = types.ModuleType("app.clients.upstage")
+    fake_module.llm = fake_llm
+    monkeypatch.setitem(sys.modules, "app.clients.upstage", fake_module)
+    return fake_llm


### PR DESCRIPTION
## 배경 및 목적

T4~T7 노드 테스트를 병렬로 작성하려면, PRD 케이스 1·2와 나머지 세그먼트 학생 데이터를 공통 fixture로 재사용할 수 있어야 합니다.

이 PR은 classify 노드와 TP 노드 테스트에서 반복적으로 필요한 학생 fixture, `ChatState` 생성 helper, FastAPI client, LLM mock을 추가하는 테스트 기반 작업입니다.

## 변경 내용

- `tests/conftest.py` 신규 작성
  - 케이스 1 학생 fixture: 1학년 국어, `못함+불성실`
  - 케이스 2 학생 fixture: 5학년 수학, `못함+성실`
  - `잘함+성실` 학생 fixture
  - `잘함+불성실` 학생 fixture
  - `make_chat_state` helper
  - FastAPI `TestClient` fixture
  - 실제 Upstage 호출을 막는 `mock_llm` fixture
- `TODO.md` T8 체크리스트 완료 처리
- 작업 워크로그 작성

## 주요 변경 파일

- `tests/conftest.py` [신규] T4~T7 노드 테스트 공통 fixture
- `TODO.md` [수정] T8 체크리스트 완료 반영
- `docs/worklogs/2026-04-28_feature-T8-conftest.md` [신규/수정] 작업 배경, 구현 방식, 검증 결과 기록

## 설계 의도

여러 팀원이 노드 테스트를 작성할 때 학생 데이터와 `ChatState` 구조가 달라지지 않도록 공통 fixture를 먼저 만들었습니다.

`mock_llm`은 `app.clients.upstage` 모듈을 fake module로 주입해 실제 Upstage API 호출을 차단합니다. 이를 통해 T5~T7 테스트가 외부 API 상태와 무관하게 안정적으로 실행될 수 있습니다.

## 결과 및 확인

- `uv run pytest` 통과
- `git diff --check` 통과

## 관련 이슈

closes #이슈번호
