### PR TITLE
test: Upstage 클라이언트 초기화 검증 추가

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -60,8 +60,8 @@ PRD 케이스 1·2가 처음부터 끝까지 작동하는 것.
 - [x] `app/clients/` 디렉토리 생성 및 `__init__.py` 추가
 - [x] `app/clients/upstage.py` — settings에서 키 읽어서 `ChatUpstage` 인스턴스 생성
 - [x] `app/clients/upstage.py` — LangSmith 트레이싱 활성화 설정
-- [ ] `tests/test_upstage_client.py` 작성 — 클라이언트 초기화 검증 (실제 API 호출은 mock)
-- [ ] **완료 기준**: `from app.clients.upstage import llm` import 정상, `uv run pytest tests/test_upstage_client.py` 통과
+- [x] `tests/test_upstage_client.py` 작성 — 클라이언트 초기화 검증 (실제 API 호출은 mock)
+- [x] **완료 기준**: `from app.clients.upstage import llm` import 정상, `uv run pytest tests/test_upstage_client.py` 통과
 
 ---
 

--- a/docs/worklogs/2026-04-28_feature-T2-upstage-client-tests.md
+++ b/docs/worklogs/2026-04-28_feature-T2-upstage-client-tests.md
@@ -3,8 +3,21 @@
 ## 작업 배경
 
 T2 Upstage 클라이언트 구현은 완료되어 있었지만, 실제 API 호출 없이 `ChatUpstage` 초기화와 LangSmith 환경 변수 설정을 검증하는 테스트가 없었다.
+T5~T7 노드에서 LLM을 호출하기 전에, `app.clients.upstage.llm` import가 안정적으로 동작하고 테스트 환경에서 외부 API로 새지 않는지 먼저 보장해야 했다.
 
-## 작업 내용
+## 왜 필요한가
+
+- Upstage API key가 잘못 연결되면 이후 TP 노드 테스트가 모두 불안정해진다.
+- LangSmith tracing 설정은 환경 변수 기반이라, 실제 import 시점에 설정되는지 테스트로 확인해야 한다.
+- 테스트에서는 실제 Upstage API 호출이 절대 발생하면 안 된다.
+
+## 구현 방법
+
+- `tests/test_upstage_client.py`에서 `langchain_upstage.ChatUpstage`를 fake class로 대체했다.
+- `settings` 값을 `monkeypatch`로 바꾼 뒤 `app.clients.upstage`를 새로 import해 모듈 초기화 동작을 검증했다.
+- `LANGSMITH_API_KEY`가 없는 경우와 있는 경우를 분리해 테스트했다.
+
+## 변경 내용
 
 - `tests/test_upstage_client.py` 신규 작성
   - `langchain_upstage.ChatUpstage`를 fake class로 대체
@@ -12,9 +25,27 @@ T2 Upstage 클라이언트 구현은 완료되어 있었지만, 실제 API 호�
   - `settings.LANGSMITH_API_KEY`가 있을 때 LangSmith tracing 환경 변수가 설정되는지 검증
 - `TODO.md` T2 테스트 체크리스트 완료 반영
 
+## 주요 변경 파일
+
+- `tests/test_upstage_client.py`
+  - fake `ChatUpstage`로 실제 API 호출을 차단하고 client 초기화 인자를 검증
+  - LangSmith tracing 환경 변수 설정 검증
+- `TODO.md`
+  - T2의 남은 테스트 항목과 완료 기준 체크
+- `docs/worklogs/2026-04-28_feature-T2-upstage-client-tests.md`
+  - 작업 배경, 구현 방식, 검증 결과 기록
+
 ## 확인
 
 - `uv run pytest tests/test_upstage_client.py` 통과
+- `uv run pytest` 통과
+- `git diff --check` 통과
+
+## PR 참고
+
+- PR 대상: `dev`
+- 이 PR은 T2 테스트 보완만 포함한다.
+- T5~T7 노드 구현 전에 먼저 머지되면 LLM client import 안정성을 확인한 상태로 다음 작업을 진행할 수 있다.
 
 ## 다음 작업
 

--- a/docs/worklogs/2026-04-28_feature-T2-upstage-client-tests.md
+++ b/docs/worklogs/2026-04-28_feature-T2-upstage-client-tests.md
@@ -1,0 +1,21 @@
+# Worklog — feature/T2-upstage-client-tests
+
+## 작업 배경
+
+T2 Upstage 클라이언트 구현은 완료되어 있었지만, 실제 API 호출 없이 `ChatUpstage` 초기화와 LangSmith 환경 변수 설정을 검증하는 테스트가 없었다.
+
+## 작업 내용
+
+- `tests/test_upstage_client.py` 신규 작성
+  - `langchain_upstage.ChatUpstage`를 fake class로 대체
+  - `settings.UPSTAGE_API_KEY`가 `ChatUpstage` 초기화에 전달되는지 검증
+  - `settings.LANGSMITH_API_KEY`가 있을 때 LangSmith tracing 환경 변수가 설정되는지 검증
+- `TODO.md` T2 테스트 체크리스트 완료 반영
+
+## 확인
+
+- `uv run pytest tests/test_upstage_client.py` 통과
+
+## 다음 작업
+
+- T4 classify 노드부터 실제 LangGraph 노드 골격 구현

--- a/tests/test_upstage_client.py
+++ b/tests/test_upstage_client.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+from app.core.config import settings
+
+
+class FakeChatUpstage:
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.__class__.instances.append(self)
+
+
+def test_upstage_client_initializes_chat_upstage_with_settings(monkeypatch):
+    fake_module = types.ModuleType("langchain_upstage")
+    fake_module.ChatUpstage = FakeChatUpstage
+    FakeChatUpstage.instances = []
+
+    monkeypatch.setitem(sys.modules, "langchain_upstage", fake_module)
+    monkeypatch.setattr(settings, "UPSTAGE_API_KEY", "test-upstage-key")
+    monkeypatch.setattr(settings, "LANGSMITH_API_KEY", "")
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
+    monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+    sys.modules.pop("app.clients.upstage", None)
+
+    upstage = importlib.import_module("app.clients.upstage")
+
+    assert upstage.llm is FakeChatUpstage.instances[0]
+    assert upstage.llm.kwargs == {
+        "api_key": "test-upstage-key",
+        "model": "solar-pro",
+    }
+
+
+def test_upstage_client_enables_langsmith_tracing_when_key_exists(monkeypatch):
+    fake_module = types.ModuleType("langchain_upstage")
+    fake_module.ChatUpstage = FakeChatUpstage
+    FakeChatUpstage.instances = []
+
+    monkeypatch.setitem(sys.modules, "langchain_upstage", fake_module)
+    monkeypatch.setattr(settings, "UPSTAGE_API_KEY", "test-upstage-key")
+    monkeypatch.setattr(settings, "LANGSMITH_API_KEY", "test-langsmith-key")
+    monkeypatch.setattr(settings, "LANGSMITH_PROJECT", "test-project")
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_PROJECT", raising=False)
+    monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+    sys.modules.pop("app.clients.upstage", None)
+
+    importlib.import_module("app.clients.upstage")
+
+    assert FakeChatUpstage.instances
+    assert os.environ["LANGCHAIN_API_KEY"] == "test-langsmith-key"
+    assert os.environ["LANGCHAIN_PROJECT"] == "test-project"
+    assert os.environ["LANGCHAIN_TRACING_V2"] == "true"


### PR DESCRIPTION
## 배경 및 목적

T2 Upstage 클라이언트 구현은 완료되어 있었지만, 실제 API 호출 없이 `ChatUpstage` 초기화와 LangSmith tracing 설정을 검증하는 테스트가 없었습니다.

이 PR은 이후 T5~T7 노드에서 LLM client를 사용할 때, `app.clients.upstage.llm` import와 설정이 안정적으로 동작하는지 보호하기 위한 테스트 보완입니다.

## 변경 내용

- `langchain_upstage.ChatUpstage`를 fake class로 대체하는 테스트 추가
- `settings.UPSTAGE_API_KEY`가 `ChatUpstage` 초기화에 전달되는지 검증
- `LANGSMITH_API_KEY`가 있을 때 LangSmith tracing 환경 변수가 설정되는지 검증
- `TODO.md` T2 테스트 항목 완료 처리
- 작업 워크로그 작성

## 주요 변경 파일

- `tests/test_upstage_client.py` [신규] Upstage client 초기화 및 LangSmith tracing 설정 테스트
- `TODO.md` [수정] T2 테스트 체크리스트 완료 반영
- `docs/worklogs/2026-04-28_feature-T2-upstage-client-tests.md` [신규] 작업 배경, 구현 방식, 검증 결과 기록

## 설계 의도

실제 Upstage API 호출 없이 client import와 초기화 동작만 검증하도록 구성했습니다.

외부 API 호출은 노드 테스트 안정성을 해치므로 fake `ChatUpstage`를 사용했습니다.

## 결과 및 확인

- `uv run pytest tests/test_upstage_client.py` 통과
- `uv run pytest` 통과
- `git diff --check` 통과

## 관련 이슈

closes #이슈번호
