### PR TITLE
feat: TP1 홈화면 진입 노드 구현 (#T5)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -150,13 +150,13 @@ PRD 케이스 1·2가 처음부터 끝까지 작동하는 것.
 **담당 파일**: `app/services/nodes/tp1.py`, `tests/test_tp1.py`
 **의존**: T1, T2, T3 | **블로킹**: T9
 
-- [ ] `tests/test_tp1.py` 작성 — 케이스 1 (lower + 못함+불성실) → 응답에 `choices` 포함, 짧고 쉬운 말투 검증
-- [ ] `tests/test_tp1.py` 작성 — 케이스 2 (upper + 못함+성실) → 응답에 `choices` 포함, 코치형 말투 검증
-- [ ] `tests/test_tp1.py` — 케이스 1과 케이스 2의 선택지 내용이 다른지 검증
-- [ ] `tp1.py` — `get_persona()` + `get_coaching_strategy()` 조합으로 시스템 프롬프트 구성
-- [ ] `tp1.py` — 학생 이름·선호 과목·AI 예상점수·오늘 태스크 컨텍스트 주입
-- [ ] `tp1.py` — 세그먼트별 선택지 생성 (PRD 1-5 + `docs/SEGMENT_RESPONSE_POLICY.md` 기준 4개 세그먼트 × 선택지)
-- [ ] **완료 기준**: `uv run pytest tests/test_tp1.py` 통과, 응답에 `TextMessage` + `ChoicesMessage` 포함 확인
+- [x] `tests/test_tp1.py` 작성 — 케이스 1 (lower + 못함+불성실) → 응답에 `choices` 포함, 짧고 쉬운 말투 검증
+- [x] `tests/test_tp1.py` 작성 — 케이스 2 (upper + 못함+성실) → 응답에 `choices` 포함, 코치형 말투 검증
+- [x] `tests/test_tp1.py` — 케이스 1과 케이스 2의 선택지 내용이 다른지 검증
+- [x] `tp1.py` — `get_persona()` + `get_coaching_strategy()` 조합으로 시스템 프롬프트 구성
+- [x] `tp1.py` — 학생 이름·선호 과목·AI 예상점수·오늘 태스크 컨텍스트 주입
+- [x] `tp1.py` — 세그먼트별 선택지 생성 (PRD 1-5 + `docs/SEGMENT_RESPONSE_POLICY.md` 기준 4개 세그먼트 × 선택지)
+- [x] **완료 기준**: `uv run pytest tests/test_tp1.py` 통과, 응답에 `TextMessage` + `ChoicesMessage` 포함 확인
 
 ---
 

--- a/app/services/nodes/tp1.py
+++ b/app/services/nodes/tp1.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from app.core.enums import Segment
+from app.core.logging import get_logger
+from app.schemas.chat import ChatResponse, ChatState
+from app.services.nodes.common import make_chat_response, make_choices, make_text
+from app.services.prompts.coaching import get_coaching_strategy
+from app.services.prompts.personas import get_persona
+
+logger = get_logger(__name__)
+
+_TP1_CHOICES: dict[Segment, tuple[tuple[str, str], ...]] = {
+    Segment.HIGH_DILIGENT: (
+        ("deep_challenge", "오늘의 심화 문제 도전하기"),
+        ("real_life_problem", "실생활 적용 문제 풀기"),
+        ("check_weak_unit", "내가 약한 단원 확인하기"),
+    ),
+    Segment.HIGH_LAZY: (
+        ("five_min_challenge", "5분만 도전 문제 풀기"),
+        ("pick_today_task", "오늘 할 것 골라주기"),
+        ("continue_yesterday", "어제 하던 학습 이어하기"),
+    ),
+    Segment.LOW_DILIGENT: (
+        ("easy_explanation", "쉬운 설명으로 다시 배우기"),
+        ("step_by_step", "한 문제를 단계별로 같이 풀기"),
+        ("find_stuck_point", "어디서 막혔는지 확인하기"),
+    ),
+    Segment.LOW_LAZY: (
+        ("one_min_reading", "1분만 짧은 글 읽어보기"),
+        ("one_easy_problem", "아주 쉬운 문제 1개만 풀기"),
+        ("picture_first", "그림 보고 먼저 보기"),
+    ),
+}
+
+
+def tp1(state: ChatState) -> ChatResponse:
+    # Lazy import so monkeypatch in tests can replace app.clients.upstage.llm
+    import sys
+    llm = sys.modules["app.clients.upstage"].llm
+
+    segment = state["segment"]
+    grade_group = state["grade_group"]
+    profile = state["student_profile"]
+    today_tasks = state["today_tasks"]
+
+    system_prompt = f"{get_persona(grade_group)}\n\n{get_coaching_strategy(segment)}"
+
+    task_lines = ""
+    if today_tasks:
+        task = today_tasks[0]
+        task_lines = (
+            f"오늘 학습: {task['subject']} - {task['unit']} "
+            f"(예상 {task['estimated_time']}분, AI 예상점수 {task['ai_predicted_score']}점)"
+        )
+
+    user_message = (
+        f"학생 이름: {profile['name']}\n"
+        f"학년: {profile['grade']}학년\n"
+        f"선호 과목: {profile['preferred_subject']}\n"
+        f"{task_lines}\n\n"
+        "지금 홈화면에 진입했습니다. 학생에게 오늘 학습을 시작하도록 안내해주세요."
+    )
+
+    logger.info(
+        "TP1 node invoked",
+        extra={
+            "student_id": state["student_id"],
+            "segment": segment.value,
+            "grade_group": grade_group.value,
+        },
+    )
+
+    response = llm.invoke([SystemMessage(content=system_prompt), HumanMessage(content=user_message)])
+
+    messages = [make_text(response.content), make_choices(_TP1_CHOICES[segment])]
+
+    logger.info(
+        "TP1 node completed",
+        extra={"student_id": state["student_id"], "message_count": len(messages)},
+    )
+
+    return make_chat_response(state["thread_id"], messages)

--- a/docs/worklogs/2026-04-28_TODO-T5.md
+++ b/docs/worklogs/2026-04-28_TODO-T5.md
@@ -1,0 +1,51 @@
+# 작업 로그 — T5 TP1 노드 (홈화면 진입)
+
+**날짜**: 2026-04-28
+**브랜치**: TODO/T5
+**담당**: T5
+
+---
+
+## 배경
+
+Phase 2 노드 구현의 첫 번째 터치포인트. 학생이 홈화면에 진입했을 때 세그먼트·학년 그룹에 맞는 환영 메시지와 학습 시작 선택지를 생성한다. 케이스 1(초1, 국어, 못함+불성실)과 케이스 2(초5, 수학, 못함+성실)의 시작점.
+
+---
+
+## 구현 내용
+
+### `app/services/nodes/__init__.py`
+- 빈 init 파일 추가 (T4와 충돌 없음 — T4 머지 시 동일 파일이므로 trivially mergeable)
+
+### `app/services/nodes/tp1.py`
+- `get_persona(grade_group)` + `get_coaching_strategy(segment)` 조합으로 시스템 프롬프트 구성
+- 학생 이름·학년·선호 과목·오늘 태스크(과목, 단원, 예상 시간, AI 예상점수)를 유저 메시지에 주입
+- LLM 호출: `sys.modules["app.clients.upstage"].llm` 방식으로 lazy 참조 — `mock_llm` 픽스처와 호환
+- 세그먼트별 선택지 `_TP1_CHOICES` (4개 세그먼트 × 3개 선택지, stable snake_case id)
+- `ChatResponse(TextMessage + ChoicesMessage)` 반환
+
+### `tests/test_tp1.py`
+- `test_case1_response_shape`: 케이스 1 → text + choices 모두 포함 확인
+- `test_case1_system_prompt_uses_lower_persona`: 시스템 프롬프트에 "이모" 또는 "삼촌" 포함 확인
+- `test_case2_response_shape`: 케이스 2 → text + choices 모두 포함 확인
+- `test_case2_system_prompt_uses_upper_persona`: 시스템 프롬프트에 "코치" 포함 확인
+- `test_choices_differ_between_cases`: 케이스 1과 케이스 2의 선택지 label이 다름 확인
+
+---
+
+## 테스트 결과
+
+```
+uv run pytest tests/test_tp1.py -v
+5 passed in 0.52s
+
+uv run pytest (전체)
+68 passed in 9.56s
+```
+
+---
+
+## 특이사항
+
+- LLM 호출 시 top-level import 대신 lazy `sys.modules` 참조를 사용 — conftest의 `mock_llm` 픽스처가 `monkeypatch.setitem(sys.modules, ...)` 방식이기 때문
+- 선택지 구조는 deterministic (세그먼트별 고정), 텍스트 내용만 LLM이 생성

--- a/tests/test_tp1.py
+++ b/tests/test_tp1.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.enums import GradeGroup, Segment, Touchpoint, UseCase
+from app.services.nodes.tp1 import tp1
+
+
+def test_case1_response_shape(case1_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case1_student,
+        segment=Segment.LOW_LAZY,
+        grade_group=GradeGroup.LOWER,
+        touchpoint=Touchpoint.TP1,
+    )
+    response = tp1(state)
+
+    types = [m.type for m in response.messages]
+    assert "text" in types
+    assert "choices" in types
+
+
+def test_case1_system_prompt_uses_lower_persona(case1_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case1_student,
+        segment=Segment.LOW_LAZY,
+        grade_group=GradeGroup.LOWER,
+        touchpoint=Touchpoint.TP1,
+    )
+    tp1(state)
+
+    system_content = mock_llm.calls[0]["messages"][0].content
+    assert "이모" in system_content or "삼촌" in system_content
+
+
+def test_case2_response_shape(case2_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case2_student,
+        segment=Segment.LOW_DILIGENT,
+        grade_group=GradeGroup.UPPER,
+        touchpoint=Touchpoint.TP1,
+    )
+    response = tp1(state)
+
+    types = [m.type for m in response.messages]
+    assert "text" in types
+    assert "choices" in types
+
+
+def test_case2_system_prompt_uses_upper_persona(case2_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case2_student,
+        segment=Segment.LOW_DILIGENT,
+        grade_group=GradeGroup.UPPER,
+        touchpoint=Touchpoint.TP1,
+    )
+    tp1(state)
+
+    system_content = mock_llm.calls[0]["messages"][0].content
+    assert "코치" in system_content
+
+
+def test_choices_differ_between_cases(case1_student, case2_student, make_chat_state, mock_llm):
+    state1 = make_chat_state(
+        case1_student,
+        segment=Segment.LOW_LAZY,
+        grade_group=GradeGroup.LOWER,
+        touchpoint=Touchpoint.TP1,
+    )
+    state2 = make_chat_state(
+        case2_student,
+        segment=Segment.LOW_DILIGENT,
+        grade_group=GradeGroup.UPPER,
+        touchpoint=Touchpoint.TP1,
+    )
+
+    response1 = tp1(state1)
+    response2 = tp1(state2)
+
+    choices1 = next(m for m in response1.messages if m.type == "choices")
+    choices2 = next(m for m in response2.messages if m.type == "choices")
+
+    labels1 = {item.label for item in choices1.items}
+    labels2 = {item.label for item in choices2.items}
+    assert labels1 != labels2


### PR DESCRIPTION
세그먼트·학년 그룹에 맞는 환영 메시지와 학습 시작 선택지를 생성하는
TP1 노드를 구현한다. 케이스 1(못함+불성실, lower)과
케이스 2(못함+성실, upper) 시작점으로 동작한다.

- app/services/nodes/tp1.py: get_persona + get_coaching_strategy 조합 시스템 프롬프트, 학생 컨텍스트 주입, 세그먼트별 선택지 생성
- tests/test_tp1.py: 응답 구조 및 말투·선택지 차이 검증 (5 passed)
- TODO.md: T5 완료 체크박스 업데이트
- docs/worklogs/2026-04-28_TODO-T5.md: 작업 로그 추가

## 배경 및 목적
<!-- 왜 이 PR이 필요한지. 어떤 TODO 항목이고, 어떤 PRD 요구사항에서 출발했는지. -->

## 변경 내용
<!-- 무엇을 구현하거나 변경했는지 요약. -->

## 주요 변경 파일
<!-- 변경된 파일마다 한 줄씩, [신규] / [수정] / [삭제] 표시 후 설명. -->
- `파일경로` [신규/수정/삭제] 설명

## 설계 의도
<!-- 핵심 결정과 그 이유. 다른 방법도 있었다면 왜 이 방향을 선택했는지. -->

## 결과 및 확인
<!-- uv run pytest 결과 붙여넣기. 테스트 없을 경우 이유 명시. -->

```
uv run pytest
```

## 워크로그 체크
- [X ] `docs/worklogs/YYYY-MM-DD_브랜치명.md` 추가 완료
- [ X] `TODO.md` 완료 항목 체크 업데이트 완료

## 관련 이슈
closes #이슈번호
