### PR TITLE
feat: TP4 노드 구현 — 학습 중 막힘 원인 진단 및 분기 코칭 (#T6)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -168,22 +168,22 @@ PRD 케이스 1·2가 처음부터 끝까지 작동하는 것.
 **담당 파일**: `app/services/nodes/tp4.py`, `tests/test_tp4.py`
 **의존**: T1, T2, T3 | **블로킹**: T9
 
-- [ ] `tests/test_tp4.py` 작성 — 케이스 1 국어: 막힘 원인 선택지 4종 응답 검증
-  - [ ] "글이 너무 길어" → `TextMessage` (문장 분리)
-  - [ ] "무슨 상황인지 모르겠어" → `ImageCardMessage` 포함
-  - [ ] "주인공 마음을 모르겠어" → `ChoicesMessage` (선택지 좁히기)
-  - [ ] "그냥 하기 싫어" → `TextMessage` (초소형 목표)
-- [ ] `tests/test_tp4.py` 작성 — 케이스 2 수학: 막힘 원인 선택지 4종 응답 검증
-  - [ ] "비율 뜻이 헷갈려" → `TextMessage` (비유 설명)
-  - [ ] "어떤 수끼리 비교해야 할지 모르겠어" → `TextMessage` (기준량/비교량 유도)
-  - [ ] "식을 어떻게 세우는지 모르겠어" → `HintCardMessage` 포함
-  - [ ] "계산하다가 틀렸어" → `TextMessage` (검산 유도)
-- [ ] `tp4.py` — 1단계: 막힘 원인 선택지 제공 (케이스별 4종)
-- [ ] `tp4.py` — 2단계: 케이스 1 국어 원인별 분기 코칭
-- [ ] `tp4.py` — 2단계: 케이스 2 수학 원인별 분기 코칭 (해설 데이터 참조)
-- [ ] `tp4.py` — 3단계: teach-back 유도 (수학, 마지막 단계에서 학생 설명 요청)
-- [ ] `tp4.py` — 내부 세그먼트명 노출 없이 `docs/SEGMENT_RESPONSE_POLICY.md`의 세그먼트별 출력 형태 반영
-- [ ] **완료 기준**: `uv run pytest tests/test_tp4.py` 통과, `HintCardMessage`·`ImageCardMessage` 타입 포함 확인
+- [x] `tests/test_tp4.py` 작성 — 케이스 1 국어: 막힘 원인 선택지 4종 응답 검증
+  - [x] "글이 너무 길어" → `TextMessage` (문장 분리)
+  - [x] "무슨 상황인지 모르겠어" → `ImageCardMessage` 포함
+  - [x] "주인공 마음을 모르겠어" → `ChoicesMessage` (선택지 좁히기)
+  - [x] "그냥 하기 싫어" → `TextMessage` (초소형 목표)
+- [x] `tests/test_tp4.py` 작성 — 케이스 2 수학: 막힘 원인 선택지 4종 응답 검증
+  - [x] "비율 뜻이 헷갈려" → `TextMessage` (비유 설명)
+  - [x] "어떤 수끼리 비교해야 할지 모르겠어" → `TextMessage` (기준량/비교량 유도)
+  - [x] "식을 어떻게 세우는지 모르겠어" → `HintCardMessage` 포함
+  - [x] "계산하다가 틀렸어" → `TextMessage` (검산 유도)
+- [x] `tp4.py` — 1단계: 막힘 원인 선택지 제공 (케이스별 4종)
+- [x] `tp4.py` — 2단계: 케이스 1 국어 원인별 분기 코칭
+- [x] `tp4.py` — 2단계: 케이스 2 수학 원인별 분기 코칭 (해설 데이터 참조)
+- [x] `tp4.py` — 3단계: teach-back 유도 (수학, 마지막 단계에서 학생 설명 요청)
+- [x] `tp4.py` — 내부 세그먼트명 노출 없이 `docs/SEGMENT_RESPONSE_POLICY.md`의 세그먼트별 출력 형태 반영
+- [x] **완료 기준**: `uv run pytest tests/test_tp4.py` 통과, `HintCardMessage`·`ImageCardMessage` 타입 포함 확인
 
 ---
 

--- a/app/services/nodes/tp4.py
+++ b/app/services/nodes/tp4.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from app.core.enums import GradeGroup, Segment, Subject, Touchpoint
+from app.core.logging import get_logger
+from app.schemas.chat import (
+    ChatState,
+    ChoicesMessage,
+    HintCardMessage,
+    ImageCardMessage,
+    ResponseMessage,
+    TextMessage,
+)
+from app.services.nodes.common import (
+    build_placeholder_messages,
+    make_choices,
+    make_hint_card,
+    make_image_card,
+    make_text,
+)
+from app.services.prompts.coaching import get_coaching_strategy
+from app.services.prompts.personas import get_persona
+
+logger = get_logger(__name__)
+
+# ─── 알려진 원인 ID 집합 ─────────────────────────────────────────────────────
+
+_KOREAN_CAUSES = {"too_long", "dont_get_situation", "dont_get_feeling", "dont_want_now"}
+_MATH_CAUSES = {"confused_concept", "find_compare_numbers", "build_expression", "check_calculation"}
+_ALL_CAUSES = _KOREAN_CAUSES | _MATH_CAUSES
+
+
+def tp4(state: ChatState) -> dict:
+    segment = state["segment"]
+    grade_group = state["grade_group"]
+
+    logger.info(
+        "tp4 노드 시작",
+        extra={
+            "student_id": state["student_id"],
+            "segment": segment.value,
+            "grade_group": grade_group.value,
+        },
+    )
+
+    cause = _get_selected_cause(state)
+
+    if cause is None:
+        messages = build_placeholder_messages(segment, grade_group, Touchpoint.TP4)
+    else:
+        messages = _build_coaching_response(state, cause)
+
+    logger.info(
+        "tp4 노드 완료",
+        extra={
+            "student_id": state["student_id"],
+            "cause": cause,
+            "message_types": [type(m).__name__ for m in messages],
+        },
+    )
+
+    return {"tp4_response": messages}
+
+
+# ─── 내부 헬퍼 ───────────────────────────────────────────────────────────────
+
+def _get_selected_cause(state: ChatState) -> str | None:
+    chat_history = state.get("chat_history", [])
+    if not chat_history:
+        return None
+
+    last = chat_history[-1]
+    # langchain HumanMessage: .type == "human"
+    if getattr(last, "type", None) == "human":
+        content = getattr(last, "content", "").strip()
+        if content in _ALL_CAUSES:
+            return content
+
+    return None
+
+
+def _build_coaching_response(state: ChatState, cause: str) -> list[ResponseMessage]:
+    segment = state["segment"]
+    grade_group = state["grade_group"]
+
+    system_prompt = _build_system_prompt(segment, grade_group, cause)
+    llm_text = _invoke_llm(system_prompt, cause)
+
+    messages: list[ResponseMessage] = _assemble_messages(cause, llm_text, state)
+
+    # 수학+성실 세그먼트: teach-back 유도 메시지 추가
+    if cause in _MATH_CAUSES and segment == Segment.LOW_DILIGENT:
+        messages.append(_make_teach_back_prompt(grade_group))
+
+    return messages
+
+
+def _build_system_prompt(segment: Segment, grade_group: GradeGroup, cause: str) -> str:
+    persona = get_persona(grade_group)
+    strategy = get_coaching_strategy(segment)
+    cause_context = _CAUSE_CONTEXT.get(cause, "")
+    return f"{persona}\n\n{strategy}\n\n현재 상황: {cause_context}"
+
+
+def _invoke_llm(system_prompt: str, cause: str) -> str:
+    from app.clients.upstage import llm
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    user_context = _CAUSE_USER_PROMPT.get(cause, "도움이 필요해요.")
+    response = llm.invoke([SystemMessage(content=system_prompt), HumanMessage(content=user_context)])
+    return response.content
+
+
+def _assemble_messages(cause: str, llm_text: str, state: ChatState) -> list[ResponseMessage]:
+    """원인별로 고정된 메시지 타입 구조에 LLM 텍스트를 채운다."""
+
+    if cause == "too_long":
+        # 문장 분리 전략 → TextMessage
+        return [make_text(llm_text)]
+
+    if cause == "dont_get_situation":
+        # 상황 이해 막힘 → TextMessage + ImageCardMessage
+        return [
+            make_text(llm_text),
+            make_image_card(
+                image_url="https://placeholder.invalid/situation_card",
+                caption="글 속 상황을 그림으로 살펴봐",
+            ),
+        ]
+
+    if cause == "dont_get_feeling":
+        # 감정 이해 막힘 → TextMessage + ChoicesMessage (감정 좁히기)
+        feeling_choices = [
+            ("happy_excited", "신나고 기쁜 느낌"),
+            ("sad_scared", "슬프거나 무서운 느낌"),
+            ("angry_upset", "화나거나 억울한 느낌"),
+            ("confused_unsure", "헷갈리고 모르겠는 느낌"),
+        ]
+        return [make_text(llm_text), make_choices(feeling_choices)]
+
+    if cause == "dont_want_now":
+        # 동기 없음 → 초소형 목표 TextMessage
+        return [make_text(llm_text)]
+
+    if cause == "confused_concept":
+        # 개념 혼동 → 비유 설명 TextMessage
+        return [make_text(llm_text)]
+
+    if cause == "find_compare_numbers":
+        # 기준량/비교량 혼동 → TextMessage
+        return [make_text(llm_text)]
+
+    if cause == "build_expression":
+        # 식 세우기 막힘 → TextMessage + HintCardMessage
+        hint_steps = [
+            "무엇을 전체(기준)로 볼지 먼저 정해요.",
+            "비교하는 양이 전체 중 얼마인지 찾아요.",
+            "비율 = 비교하는 양 ÷ 기준량 식을 써요.",
+        ]
+        return [make_text(llm_text), make_hint_card(hint_steps)]
+
+    if cause == "check_calculation":
+        # 계산 오류 → 검산 유도 TextMessage
+        return [make_text(llm_text)]
+
+    # 예상하지 못한 cause는 기본 텍스트 응답
+    return [make_text(llm_text)]
+
+
+def _make_teach_back_prompt(grade_group: GradeGroup) -> TextMessage:
+    prompts = {
+        GradeGroup.LOWER: "이제 네가 한 번 설명해줄 수 있어?",
+        GradeGroup.MIDDLE: "이제 네 말로 한 번 설명해볼 수 있어?",
+        GradeGroup.UPPER: "이제 방금 푼 방법을 본인 말로 한 번 설명해볼 수 있어요?",
+    }
+    return make_text(prompts.get(grade_group, "이제 네 말로 설명해볼까요?"))
+
+
+# ─── 원인별 컨텍스트·프롬프트 ────────────────────────────────────────────────
+
+_CAUSE_CONTEXT: dict[str, str] = {
+    "too_long": "학생이 글이 너무 길어서 읽기 어렵다고 했어. 문장을 짧게 나눠 읽는 방법을 알려줘.",
+    "dont_get_situation": "학생이 글 속 상황이 무슨 상황인지 모르겠다고 했어. 상황을 그림처럼 떠올리도록 도와줘.",
+    "dont_get_feeling": "학생이 주인공의 마음을 모르겠다고 했어. 감정을 좁혀가는 선택지로 유도해줘.",
+    "dont_want_now": "학생이 지금 하기 싫다고 했어. 아주 작은 한 가지 목표만 제시해줘.",
+    "confused_concept": "학생이 비율 개념이 헷갈린다고 했어. 일상 속 비유로 쉽게 설명해줘.",
+    "find_compare_numbers": "학생이 어떤 수끼리 비교해야 할지 모르겠다고 했어. 기준량과 비교량을 찾는 방법을 유도해줘.",
+    "build_expression": "학생이 식을 어떻게 세우는지 모르겠다고 했어. 단계별 힌트로 식 세우기를 도와줘.",
+    "check_calculation": "학생이 계산하다가 틀렸다고 했어. 검산 방법을 단계적으로 유도해줘.",
+}
+
+_CAUSE_USER_PROMPT: dict[str, str] = {
+    "too_long": "글이 너무 길어서 어떻게 읽어야 할지 모르겠어요.",
+    "dont_get_situation": "무슨 상황인지 잘 모르겠어요.",
+    "dont_get_feeling": "주인공이 어떤 마음인지 모르겠어요.",
+    "dont_want_now": "지금 하기 싫어요.",
+    "confused_concept": "비율이 무슨 뜻인지 헷갈려요.",
+    "find_compare_numbers": "어떤 수끼리 비교해야 할지 모르겠어요.",
+    "build_expression": "식을 어떻게 세우는지 모르겠어요.",
+    "check_calculation": "계산하다가 틀렸어요.",
+}

--- a/docs/worklogs/2026-04-28_feature-T6-tp4-node.md
+++ b/docs/worklogs/2026-04-28_feature-T6-tp4-node.md
@@ -1,0 +1,60 @@
+# 워크로그 — feature/T6-tp4-node
+
+**날짜**: 2026-04-28
+**작업자**: Luke
+**브랜치**: feature/T6-tp4-node
+
+---
+
+## 작업 개요
+
+TP4 노드(학습 중 도움 요청) 구현. 케이스 1(저학년 국어, 못함+불성실)과 케이스 2(고학년 수학, 못함+성실)에서 막힘 원인을 선택지로 진단하고, 원인별로 분기 코칭 응답을 반환한다.
+
+---
+
+## 구현 세부
+
+### 흐름
+
+1. **1단계 (원인 미선택)**: `chat_history`에 원인 HumanMessage가 없으면 `build_placeholder_messages`로 진단 선택지 4종 반환
+2. **2단계 (원인 선택 후)**: 마지막 HumanMessage의 content가 알려진 cause ID이면 원인별 분기 코칭 응답 조립
+3. **3단계 (teach-back)**: `Segment.LOW_DILIGENT` + 수학 원인 조합이면 마지막에 teach-back TextMessage 자동 추가
+
+### 원인 → 메시지 타입
+
+| cause | 응답 타입 |
+|---|---|
+| `too_long` | TextMessage |
+| `dont_get_situation` | TextMessage + ImageCardMessage |
+| `dont_get_feeling` | TextMessage + ChoicesMessage(감정 좁히기) |
+| `dont_want_now` | TextMessage |
+| `confused_concept` | TextMessage |
+| `find_compare_numbers` | TextMessage |
+| `build_expression` | TextMessage + HintCardMessage(3단계) |
+| `check_calculation` | TextMessage |
+
+### 설계 결정
+
+- `chat_history`의 마지막 `HumanMessage.content`로 원인을 감지 — 별도 ChatState 필드 추가 없이 LangGraph 표준 state 활용
+- 메시지 타입 구조는 코드에서 고정, 텍스트 내용은 LLM 생성 (SEGMENT_RESPONSE_POLICY.md 원칙 준수)
+- 내부 세그먼트명(LOW_LAZY 등)은 응답 메시지 어디에도 노출하지 않음
+
+---
+
+## 테스트 결과
+
+```
+uv run pytest tests/test_tp4.py -v
+============================= 15 passed in 0.08s ==============================
+
+uv run pytest
+============================= 78 passed in 4.41s ==============================
+```
+
+---
+
+## 변경 파일
+
+- `app/services/nodes/tp4.py` [신규]
+- `tests/test_tp4.py` [신규]
+- `TODO.md` [수정] — T6 체크박스 완료 처리

--- a/tests/test_tp4.py
+++ b/tests/test_tp4.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from app.core.enums import GradeGroup, Segment, Touchpoint, UseCase
+from app.schemas.chat import (
+    ChoicesMessage,
+    HintCardMessage,
+    ImageCardMessage,
+    TextMessage,
+)
+from app.services.nodes.tp4 import tp4
+
+
+# ─── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+def _has_type(messages, msg_type) -> bool:
+    return any(isinstance(m, msg_type) for m in messages)
+
+
+def _state_with_cause(make_chat_state, student, segment, grade_group, cause: str | None):
+    state = make_chat_state(
+        student,
+        segment=segment,
+        grade_group=grade_group,
+        use_case=UseCase.LEARNING,
+        touchpoint=Touchpoint.TP4,
+    )
+    if cause:
+        state["chat_history"] = [HumanMessage(content=cause)]
+    return state
+
+
+# ─── 케이스 1 (국어, LOW_LAZY, LOWER) ────────────────────────────────────────
+
+class TestTp4Case1Korean:
+    """케이스 1: 저학년 국어, 못함+불성실 세그먼트"""
+
+    def _make_state(self, make_chat_state, case1_student, cause: str | None):
+        return _state_with_cause(
+            make_chat_state, case1_student, Segment.LOW_LAZY, GradeGroup.LOWER, cause
+        )
+
+    def test_no_cause_returns_choices(self, make_chat_state, case1_student, mock_llm):
+        state = self._make_state(make_chat_state, case1_student, None)
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, TextMessage)
+        assert _has_type(messages, ChoicesMessage)
+
+    def test_too_long_returns_text(self, make_chat_state, case1_student, mock_llm):
+        state = self._make_state(make_chat_state, case1_student, "too_long")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, TextMessage)
+
+    def test_dont_get_situation_returns_image_card(self, make_chat_state, case1_student, mock_llm):
+        state = self._make_state(make_chat_state, case1_student, "dont_get_situation")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, ImageCardMessage)
+
+    def test_dont_get_feeling_returns_choices(self, make_chat_state, case1_student, mock_llm):
+        state = self._make_state(make_chat_state, case1_student, "dont_get_feeling")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, ChoicesMessage)
+
+    def test_dont_want_now_returns_text(self, make_chat_state, case1_student, mock_llm):
+        state = self._make_state(make_chat_state, case1_student, "dont_want_now")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, TextMessage)
+
+    def test_no_teach_back_for_case1(self, make_chat_state, case1_student, mock_llm):
+        # 국어(LOW_LAZY)는 teach-back을 추가하지 않는다
+        state = self._make_state(make_chat_state, case1_student, "too_long")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        # LOW_LAZY는 teach-back 없음 → TextMessage 1개만
+        assert len(messages) == 1
+
+
+# ─── 케이스 2 (수학, LOW_DILIGENT, UPPER) ────────────────────────────────────
+
+class TestTp4Case2Math:
+    """케이스 2: 고학년 수학, 못함+성실 세그먼트"""
+
+    def _make_state(self, make_chat_state, case2_student, cause: str | None):
+        return _state_with_cause(
+            make_chat_state, case2_student, Segment.LOW_DILIGENT, GradeGroup.UPPER, cause
+        )
+
+    def test_no_cause_returns_choices(self, make_chat_state, case2_student, mock_llm):
+        state = self._make_state(make_chat_state, case2_student, None)
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, TextMessage)
+        assert _has_type(messages, ChoicesMessage)
+
+    def test_confused_concept_returns_text(self, make_chat_state, case2_student, mock_llm):
+        state = self._make_state(make_chat_state, case2_student, "confused_concept")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, TextMessage)
+
+    def test_find_compare_numbers_returns_text(self, make_chat_state, case2_student, mock_llm):
+        state = self._make_state(make_chat_state, case2_student, "find_compare_numbers")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, TextMessage)
+
+    def test_build_expression_returns_hint_card(self, make_chat_state, case2_student, mock_llm):
+        state = self._make_state(make_chat_state, case2_student, "build_expression")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, HintCardMessage)
+
+    def test_check_calculation_returns_text(self, make_chat_state, case2_student, mock_llm):
+        state = self._make_state(make_chat_state, case2_student, "check_calculation")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        assert _has_type(messages, TextMessage)
+
+    def test_teach_back_appended_for_math_low_diligent(
+        self, make_chat_state, case2_student, mock_llm
+    ):
+        # 수학 LOW_DILIGENT는 마지막에 teach-back TextMessage를 추가한다
+        for cause in ("confused_concept", "find_compare_numbers", "build_expression", "check_calculation"):
+            state = self._make_state(make_chat_state, case2_student, cause)
+            result = tp4(state)
+            messages = result["tp4_response"]
+
+            last = messages[-1]
+            assert isinstance(last, TextMessage), f"cause={cause}: 마지막 메시지가 TextMessage여야 함"
+
+    def test_build_expression_hint_card_has_steps(
+        self, make_chat_state, case2_student, mock_llm
+    ):
+        state = self._make_state(make_chat_state, case2_student, "build_expression")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        hint_cards = [m for m in messages if isinstance(m, HintCardMessage)]
+        assert hint_cards, "HintCardMessage가 없음"
+        assert len(hint_cards[0].steps) >= 2, "힌트 단계가 2개 이상이어야 함"
+
+
+# ─── 세그먼트명 노출 방지 ─────────────────────────────────────────────────────
+
+class TestTp4SegmentNotExposed:
+    """내부 세그먼트 식별자가 응답 메시지에 노출되지 않아야 한다."""
+
+    INTERNAL_NAMES = ["LOW_LAZY", "LOW_DILIGENT", "HIGH_LAZY", "HIGH_DILIGENT",
+                      "못함+불성실", "못함+성실", "잘함+불성실", "잘함+성실"]
+
+    def _check_no_segment_in_messages(self, messages):
+        for m in messages:
+            for name in self.INTERNAL_NAMES:
+                if isinstance(m, TextMessage):
+                    assert name not in m.content, f"세그먼트명 '{name}'이 TextMessage에 노출됨"
+                elif isinstance(m, ChoicesMessage):
+                    for item in m.items:
+                        assert name not in item.label, f"세그먼트명 '{name}'이 선택지 label에 노출됨"
+                elif isinstance(m, ImageCardMessage):
+                    assert name not in m.caption
+                elif isinstance(m, HintCardMessage):
+                    for step in m.steps:
+                        assert name not in step.content
+
+    def test_case1_no_cause(self, make_chat_state, case1_student, mock_llm):
+        state = _state_with_cause(
+            make_chat_state, case1_student, Segment.LOW_LAZY, GradeGroup.LOWER, None
+        )
+        result = tp4(state)
+        self._check_no_segment_in_messages(result["tp4_response"])
+
+    def test_case2_build_expression(self, make_chat_state, case2_student, mock_llm):
+        state = _state_with_cause(
+            make_chat_state, case2_student, Segment.LOW_DILIGENT, GradeGroup.UPPER, "build_expression"
+        )
+        result = tp4(state)
+        self._check_no_segment_in_messages(result["tp4_response"])


### PR DESCRIPTION
  본문:
  ## 배경 및 목적
  TODO.md T6 항목. PRD 케이스 1(저학년 국어, 못함+불성실)·케이스 2(고학년 수학, 못함+성실)에서
  학습 중 도움 요청 시 막힘 원인을 선택지로 진단하고 원인에 따라 분기 코칭하는 TP4 노드 구현.

  ## 변경 내용
  - 막힘 원인 미선택 시 진단 선택지 4종 반환 (1단계)
  - chat_history 마지막 HumanMessage로 원인 감지, 원인별 코칭 응답 조립 (2단계)
  - LOW_DILIGENT + 수학 조합에서 teach-back TextMessage 자동 추가 (3단계)
  - 내부 세그먼트명이 응답에 노출되지 않는 것 테스트로 검증

  ## 주요 변경 파일
  - `app/services/nodes/tp4.py` [신규]
  - `tests/test_tp4.py` [신규] — 15개 테스트

  ## 설계 의도
  - 메시지 타입 구조는 코드에서 고정, LLM은 텍스트 내용만 생성 (SEGMENT_RESPONSE_POLICY.md 원칙)
  - 원인 감지를 별도 필드 없이 chat_history 마지막 HumanMessage content로 처리

  ## 결과 및 확인
  uv run pytest → 78 passed in 4.41s

  ## 워크로그 체크
  - [x] docs/worklogs/2026-04-28_feature-T6-tp4-node.md 추가 완료
  - [x] TODO.md 완료 항목 체크 업데이트 완료

  ## 관련 이슈
  closes #T6

  base 브랜치: dev
