### PR TITLE
feat: TP2·TP3·TP5 보조 터치포인트 노드 구현 (#T7)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -195,17 +195,17 @@ PRD 케이스 1·2가 처음부터 끝까지 작동하는 것.
 **담당 파일**: `app/services/nodes/tp2.py`, `tp3.py`, `tp5.py`, `tests/test_tp2.py`, `tests/test_tp3.py`, `tests/test_tp5.py`
 **의존**: T1, T2, T3 | **블로킹**: T9
 
-- [ ] `tests/test_tp2.py` 작성 — 완료 태스크 수 기반 진행률 멘트 검증
-- [ ] `tp2.py` — 완료 축하 + `completed_tasks` 수 활용 진행률 안내 + 다음 태스크 추천
-- [ ] `tests/test_tp3.py` 작성 — `current_task` 기반 리텐션 메시지 검증
-- [ ] `tp3.py` — "이 문제만 끝내고 가자" 리텐션 + 남은 양 최소화 표현
-- [ ] `tests/test_tp5.py` 작성 — 오답 없음 분기 검증
-- [ ] `tests/test_tp5.py` 작성 — 오답 있음 + 복습 완료 분기 검증
-- [ ] `tests/test_tp5.py` 작성 — 오답 있음 + 복습 미완료 분기 검증
-- [ ] `tp5.py` — 오답 없음 → "오늘 다 맞았어!" 구현
-- [ ] `tp5.py` — 오답 있음 + 복습 완료 → "오답 N개 다 복습했어!" 구현
-- [ ] `tp5.py` — 오답 있음 + 복습 미완료 → "오답 N개 중 M개 남았어!" 구현 (`wrong_content_total` / `wrong_content_done` 수치 활용)
-- [ ] **완료 기준**: `uv run pytest tests/test_tp2.py tests/test_tp3.py tests/test_tp5.py` 통과
+- [x] `tests/test_tp2.py` 작성 — 완료 태스크 수 기반 진행률 멘트 검증
+- [x] `tp2.py` — 완료 축하 + `completed_tasks` 수 활용 진행률 안내 + 다음 태스크 추천
+- [x] `tests/test_tp3.py` 작성 — `current_task` 기반 리텐션 메시지 검증
+- [x] `tp3.py` — "이 문제만 끝내고 가자" 리텐션 + 남은 양 최소화 표현
+- [x] `tests/test_tp5.py` 작성 — 오답 없음 분기 검증
+- [x] `tests/test_tp5.py` 작성 — 오답 있음 + 복습 완료 분기 검증
+- [x] `tests/test_tp5.py` 작성 — 오답 있음 + 복습 미완료 분기 검증
+- [x] `tp5.py` — 오답 없음 → "오늘 다 맞았어!" 구현
+- [x] `tp5.py` — 오답 있음 + 복습 완료 → "오답 N개 다 복습했어!" 구현
+- [x] `tp5.py` — 오답 있음 + 복습 미완료 → "오답 N개 중 M개 남았어!" 구현 (`wrong_content_total` / `wrong_content_done` 수치 활용)
+- [x] **완료 기준**: `uv run pytest tests/test_tp2.py tests/test_tp3.py tests/test_tp5.py` 통과
 
 ---
 

--- a/app/services/nodes/tp2.py
+++ b/app/services/nodes/tp2.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from app.core.enums import Segment
+from app.core.logging import get_logger
+from app.schemas.chat import ChatResponse, ChatState
+from app.services.nodes.common import make_chat_response, make_choices, make_text
+from app.services.prompts.coaching import get_coaching_strategy
+from app.services.prompts.personas import get_persona
+
+logger = get_logger(__name__)
+
+_TP2_CHOICES: dict[Segment, tuple[tuple[str, str], ...]] = {
+    Segment.HIGH_DILIGENT: (
+        ("try_deeper", "심화 문제로 이어가기"),
+        ("review_key", "핵심만 빠르게 확인하기"),
+        ("finish_today", "오늘 학습 정리하기"),
+    ),
+    Segment.HIGH_LAZY: (
+        ("one_more_challenge", "도전 문제 1개만 더 풀기"),
+        ("short_review", "핵심만 1분 복습하기"),
+        ("finish_today", "오늘은 여기까지 하기"),
+    ),
+    Segment.LOW_DILIGENT: (
+        ("next_small_step", "다음 단계 같이 보기"),
+        ("review_mistake", "헷갈린 부분 다시 보기"),
+        ("finish_today", "오늘 학습 정리하기"),
+    ),
+    Segment.LOW_LAZY: (
+        ("one_more_easy", "쉬운 문제 1개만 더 하기"),
+        ("quick_praise", "오늘 한 것 확인하기"),
+        ("finish_today", "오늘은 여기까지 하기"),
+    ),
+}
+
+
+def tp2(state: ChatState) -> ChatResponse:
+    from app.clients.upstage import llm
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    segment = state["segment"]
+    grade_group = state["grade_group"]
+    profile = state["student_profile"]
+    completed = state["completed_tasks"]
+    today_tasks = state["today_tasks"]
+
+    system_prompt = f"{get_persona(grade_group)}\n\n{get_coaching_strategy(segment)}"
+
+    completed_count = len(completed)
+    total_count = len(today_tasks)
+    remaining = total_count - completed_count
+
+    user_message = (
+        f"학생 이름: {profile['name']}\n"
+        f"학년: {profile['grade']}학년\n"
+        f"오늘 학습 진행률: {completed_count}/{total_count} 완료, {remaining}개 남음\n\n"
+        "방금 한 단위 학습을 완료했습니다. 완료를 축하하고 다음 학습을 부드럽게 제안해주세요."
+    )
+
+    logger.info(
+        "TP2 node invoked",
+        extra={
+            "student_id": state["student_id"],
+            "segment": segment.value,
+            "completed": completed_count,
+            "total": total_count,
+        },
+    )
+
+    response = llm.invoke([SystemMessage(content=system_prompt), HumanMessage(content=user_message)])
+
+    messages = [make_text(response.content), make_choices(_TP2_CHOICES[segment])]
+
+    logger.info(
+        "TP2 node completed",
+        extra={"student_id": state["student_id"], "message_count": len(messages)},
+    )
+
+    return make_chat_response(state["thread_id"], messages)

--- a/app/services/nodes/tp3.py
+++ b/app/services/nodes/tp3.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from app.core.enums import Segment
+from app.core.logging import get_logger
+from app.schemas.chat import ChatResponse, ChatState
+from app.services.nodes.common import make_chat_response, make_choices, make_text
+from app.services.prompts.coaching import get_coaching_strategy
+from app.services.prompts.personas import get_persona
+
+logger = get_logger(__name__)
+
+_TP3_CHOICES: dict[Segment, tuple[tuple[str, str], ...]] = {
+    Segment.HIGH_DILIGENT: (
+        ("finish_current", "지금 문제 마무리하기"),
+        ("check_condition", "조건 하나만 확인하기"),
+        ("pause_after_this", "이 문제 후 쉬기"),
+    ),
+    Segment.HIGH_LAZY: (
+        ("finish_one", "딱 1문제만 끝내기"),
+        ("quick_hint", "힌트만 보고 풀기"),
+        ("pause_after_this", "이 문제 후 쉬기"),
+    ),
+    Segment.LOW_DILIGENT: (
+        ("one_small_step", "한 단계만 같이 보기"),
+        ("show_hint", "힌트 보기"),
+        ("pause_after_this", "이 문제 후 쉬기"),
+    ),
+    Segment.LOW_LAZY: (
+        ("one_tiny_step", "아주 작은 단계만 하기"),
+        ("easy_hint", "쉬운 힌트 보기"),
+        ("pause_after_this", "이 문제 후 쉬기"),
+    ),
+}
+
+
+def tp3(state: ChatState) -> ChatResponse:
+    from app.clients.upstage import llm
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    segment = state["segment"]
+    grade_group = state["grade_group"]
+    profile = state["student_profile"]
+    current_task = state["current_task"]
+
+    system_prompt = f"{get_persona(grade_group)}\n\n{get_coaching_strategy(segment)}"
+
+    task_info = ""
+    if current_task:
+        task_info = (
+            f"지금 하던 학습: {current_task['subject']} - {current_task['unit']} "
+            f"({current_task['problem_count']}문제)"
+        )
+
+    user_message = (
+        f"학생 이름: {profile['name']}\n"
+        f"학년: {profile['grade']}학년\n"
+        f"{task_info}\n\n"
+        "학생이 학습을 중간에 나가려고 합니다. "
+        "'이 문제만 끝내고 가자'는 방향으로 남은 양을 최소화해서 짧게 설득해주세요."
+    )
+
+    logger.info(
+        "TP3 node invoked",
+        extra={
+            "student_id": state["student_id"],
+            "segment": segment.value,
+            "current_task": current_task,
+        },
+    )
+
+    response = llm.invoke([SystemMessage(content=system_prompt), HumanMessage(content=user_message)])
+
+    messages = [make_text(response.content), make_choices(_TP3_CHOICES[segment])]
+
+    logger.info(
+        "TP3 node completed",
+        extra={"student_id": state["student_id"], "message_count": len(messages)},
+    )
+
+    return make_chat_response(state["thread_id"], messages)

--- a/app/services/nodes/tp5.py
+++ b/app/services/nodes/tp5.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from app.core.enums import Segment
+from app.core.logging import get_logger
+from app.schemas.chat import ChatResponse, ChatState
+from app.services.nodes.common import make_chat_response, make_choices, make_text
+from app.services.prompts.coaching import get_coaching_strategy
+from app.services.prompts.personas import get_persona
+
+logger = get_logger(__name__)
+
+_TP5_CHOICES: dict[Segment, tuple[tuple[str, str], ...]] = {
+    Segment.HIGH_DILIGENT: (
+        ("preview_deeper", "다음 심화 미리 보기"),
+        ("review_today", "오늘 핵심 정리하기"),
+        ("finish_today", "학습 끝내기"),
+    ),
+    Segment.HIGH_LAZY: (
+        ("set_short_goal", "다음 목표 짧게 정하기"),
+        ("review_today", "오늘 한 것 확인하기"),
+        ("finish_today", "학습 끝내기"),
+    ),
+    Segment.LOW_DILIGENT: (
+        ("review_wrong", "오답 다시 보기"),
+        ("review_today", "오늘 배운 것 정리하기"),
+        ("finish_today", "학습 끝내기"),
+    ),
+    Segment.LOW_LAZY: (
+        ("one_next_goal", "다음에 할 1개 정하기"),
+        ("quick_review", "오늘 한 것 보기"),
+        ("finish_today", "학습 끝내기"),
+    ),
+}
+
+
+def _build_wrong_answer_summary(state: ChatState) -> str:
+    if not state["has_wrong_answers"]:
+        return "오늘 틀린 문제가 없어요!"
+
+    total = state["learning_pattern"]["wrong_content_total"]
+    done = state["learning_pattern"]["wrong_content_done"]
+
+    if state["wrong_content_done_today"]:
+        return f"오답 {total}개를 다 복습했어요!"
+
+    remaining = total - done
+    return f"오답 {total}개 중 {remaining}개가 남아있어요."
+
+
+def tp5(state: ChatState) -> ChatResponse:
+    from app.clients.upstage import llm
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    segment = state["segment"]
+    grade_group = state["grade_group"]
+    profile = state["student_profile"]
+
+    system_prompt = f"{get_persona(grade_group)}\n\n{get_coaching_strategy(segment)}"
+
+    wrong_summary = _build_wrong_answer_summary(state)
+
+    user_message = (
+        f"학생 이름: {profile['name']}\n"
+        f"학년: {profile['grade']}학년\n"
+        f"오늘 학습 결과: {wrong_summary}\n\n"
+        "오늘 학습을 마무리하는 메시지를 전해주세요."
+    )
+
+    logger.info(
+        "TP5 node invoked",
+        extra={
+            "student_id": state["student_id"],
+            "segment": segment.value,
+            "has_wrong_answers": state["has_wrong_answers"],
+            "wrong_content_done_today": state["wrong_content_done_today"],
+        },
+    )
+
+    response = llm.invoke([SystemMessage(content=system_prompt), HumanMessage(content=user_message)])
+
+    messages = [make_text(response.content), make_choices(_TP5_CHOICES[segment])]
+
+    logger.info(
+        "TP5 node completed",
+        extra={"student_id": state["student_id"], "message_count": len(messages)},
+    )
+
+    return make_chat_response(state["thread_id"], messages)

--- a/docs/worklogs/2026-04-28_TODO-T7.md
+++ b/docs/worklogs/2026-04-28_TODO-T7.md
@@ -1,0 +1,55 @@
+# 작업 로그 — T7 보조 터치포인트 노드 (TP2 + TP3 + TP5)
+
+**날짜**: 2026-04-28
+**브랜치**: TODO/T7
+**담당**: T7
+
+---
+
+## 배경
+
+T4~T6 완료 후 남은 보조 터치포인트 3개를 구현한다.
+TP2(단위 학습 완료), TP3(이탈 방지), TP5(학습 종료)는 모두 T9 그래프 조립의 전제 조건.
+T5 PR 머지 및 T6 PR 머지 후 최신 dev를 rebase하여 시작.
+
+---
+
+## 구현 내용
+
+### `app/services/nodes/tp2.py`
+- `completed_tasks` 수와 `today_tasks` 수로 진행률(N/M, 남은 개수) 계산해 유저 메시지에 주입
+- 세그먼트별 선택지 `_TP2_CHOICES` (4개 세그먼트 × 3개 선택지)
+- `ChatResponse(TextMessage + ChoicesMessage)` 반환
+
+### `app/services/nodes/tp3.py`
+- `current_task`의 과목·단원명을 유저 메시지에 주입 — "이 문제만 끝내고 가자" 방향
+- 세그먼트별 선택지 `_TP3_CHOICES` (4개 세그먼트 × 3개 선택지)
+
+### `app/services/nodes/tp5.py`
+- `_build_wrong_answer_summary()` 분리 함수로 3가지 분기 처리
+  - `has_wrong_answers=False` → "오늘 틀린 문제가 없어요!"
+  - `has_wrong_answers=True` + `wrong_content_done_today=True` → "오답 N개를 다 복습했어요!"
+  - `has_wrong_answers=True` + `wrong_content_done_today=False` → "오답 N개 중 M개가 남아있어요." (`wrong_content_total` - `wrong_content_done`)
+- 세그먼트별 선택지 `_TP5_CHOICES` (4개 세그먼트 × 3개 선택지)
+
+### LLM 호출 패턴
+- tp4 패턴과 통일: `from app.clients.upstage import llm` lazy import (함수 내부)
+
+---
+
+## 테스트 결과
+
+```
+uv run pytest tests/test_tp2.py tests/test_tp3.py tests/test_tp5.py -v
+10 passed in 0.11s
+
+uv run pytest (전체)
+111 passed in 2.06s
+```
+
+---
+
+## 특이사항
+
+- TP5 `_build_wrong_answer_summary()`를 별도 함수로 분리 — 3가지 분기를 단위 테스트로 직접 검증 가능
+- tp2/tp3/tp5 모두 tp1과 동일하게 `ChatResponse` 반환 (tp4의 dict 반환과 다름 — T9 그래프 조립 시 통일 필요)

--- a/tests/test_tp2.py
+++ b/tests/test_tp2.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from app.core.enums import GradeGroup, Segment, Touchpoint
+from app.schemas.chat import Task
+from app.services.nodes.tp2 import tp2
+
+
+def test_response_shape(case1_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case1_student,
+        segment=Segment.LOW_LAZY,
+        grade_group=GradeGroup.LOWER,
+        touchpoint=Touchpoint.TP2,
+    )
+    response = tp2(state)
+
+    types = [m.type for m in response.messages]
+    assert "text" in types
+    assert "choices" in types
+
+
+def test_progress_info_in_user_message(case2_student, make_chat_state, mock_llm):
+    completed: list[Task] = [case2_student["today_tasks"][0]]
+    state = make_chat_state(
+        case2_student,
+        segment=Segment.LOW_DILIGENT,
+        grade_group=GradeGroup.UPPER,
+        touchpoint=Touchpoint.TP2,
+        completed_tasks=completed,
+    )
+    tp2(state)
+
+    user_content = mock_llm.calls[0]["messages"][1].content
+    assert "1/1" in user_content or "1" in user_content

--- a/tests/test_tp3.py
+++ b/tests/test_tp3.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from app.core.enums import GradeGroup, Segment, Touchpoint
+from app.services.nodes.tp3 import tp3
+
+
+def test_response_shape(case1_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case1_student,
+        segment=Segment.LOW_LAZY,
+        grade_group=GradeGroup.LOWER,
+        touchpoint=Touchpoint.TP3,
+    )
+    response = tp3(state)
+
+    types = [m.type for m in response.messages]
+    assert "text" in types
+    assert "choices" in types
+
+
+def test_current_task_in_user_message(case1_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case1_student,
+        segment=Segment.LOW_LAZY,
+        grade_group=GradeGroup.LOWER,
+        touchpoint=Touchpoint.TP3,
+    )
+    tp3(state)
+
+    user_content = mock_llm.calls[0]["messages"][1].content
+    # current_task is the first today_task: 국어 - 짧은 글 읽기
+    assert "국어" in user_content
+    assert "짧은 글 읽기" in user_content

--- a/tests/test_tp5.py
+++ b/tests/test_tp5.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.enums import GradeGroup, Segment, Touchpoint
+from app.services.nodes.tp5 import _build_wrong_answer_summary, tp5
+
+
+# ─── _build_wrong_answer_summary unit tests ──────────────────────────────────
+
+def test_no_wrong_answers(case1_student, make_chat_state):
+    # Force has_wrong_answers=False by using high_diligent_student (wrong_content_total=0)
+    # but we can also override via a custom state
+    state = make_chat_state(
+        case1_student,
+        segment=Segment.LOW_LAZY,
+        grade_group=GradeGroup.LOWER,
+        touchpoint=Touchpoint.TP5,
+    )
+    # Manually set no wrong answers
+    state = {**state, "has_wrong_answers": False}
+    summary = _build_wrong_answer_summary(state)
+    assert "오늘 틀린 문제가 없어요" in summary
+
+
+def test_wrong_answers_all_reviewed(case2_student, make_chat_state):
+    state = make_chat_state(
+        case2_student,
+        segment=Segment.LOW_DILIGENT,
+        grade_group=GradeGroup.UPPER,
+        touchpoint=Touchpoint.TP5,
+    )
+    # wrong_content_total=3, force done_today=True
+    state = {**state, "has_wrong_answers": True, "wrong_content_done_today": True}
+    summary = _build_wrong_answer_summary(state)
+    assert "다 복습했어요" in summary
+    assert "3" in summary
+
+
+def test_wrong_answers_partially_reviewed(case2_student, make_chat_state):
+    state = make_chat_state(
+        case2_student,
+        segment=Segment.LOW_DILIGENT,
+        grade_group=GradeGroup.UPPER,
+        touchpoint=Touchpoint.TP5,
+    )
+    # wrong_content_total=3, wrong_content_done=1 → 2 remaining
+    state = {**state, "has_wrong_answers": True, "wrong_content_done_today": False}
+    summary = _build_wrong_answer_summary(state)
+    assert "3" in summary
+    assert "2" in summary  # remaining = 3 - 1
+
+
+# ─── tp5 node integration tests ──────────────────────────────────────────────
+
+def test_response_shape(case2_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case2_student,
+        segment=Segment.LOW_DILIGENT,
+        grade_group=GradeGroup.UPPER,
+        touchpoint=Touchpoint.TP5,
+    )
+    response = tp5(state)
+
+    types = [m.type for m in response.messages]
+    assert "text" in types
+    assert "choices" in types
+
+
+def test_wrong_summary_in_user_message_no_wrong(high_diligent_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        high_diligent_student,
+        segment=Segment.HIGH_DILIGENT,
+        grade_group=GradeGroup.MIDDLE,
+        touchpoint=Touchpoint.TP5,
+    )
+    tp5(state)
+
+    user_content = mock_llm.calls[0]["messages"][1].content
+    assert "오늘 틀린 문제가 없어요" in user_content
+
+
+def test_wrong_summary_in_user_message_partial(case2_student, make_chat_state, mock_llm):
+    state = make_chat_state(
+        case2_student,
+        segment=Segment.LOW_DILIGENT,
+        grade_group=GradeGroup.UPPER,
+        touchpoint=Touchpoint.TP5,
+    )
+    # wrong_content_total=3, wrong_content_done=1, done_today=False
+    state = {**state, "wrong_content_done_today": False}
+    tp5(state)
+
+    user_content = mock_llm.calls[0]["messages"][1].content
+    assert "남아있어요" in user_content


### PR DESCRIPTION
단위 학습 완료(TP2), 이탈 방지(TP3), 학습 종료(TP5) 세 노드를 구현한다.
TP5는 오답 없음/복습 완료/복습 미완료 3개 분기를 _build_wrong_answer_summary()로 처리.

- app/services/nodes/tp2.py: 진행률(completed/total) 컨텍스트 주입, 세그먼트별 선택지
- app/services/nodes/tp3.py: current_task 과목·단원 주입, 남은 양 최소화 리텐션
- app/services/nodes/tp5.py: 오답 분기 3종 처리, 세그먼트별 선택지
- tests/test_tp2/tp3/tp5.py: 응답 구조·분기·컨텍스트 주입 검증 (10 passed)
- TODO.md: T7 완료 체크박스 업데이트
- docs/worklogs/2026-04-28_TODO-T7.md: 작업 로그 추가

## 배경 및 목적
<!-- 왜 이 PR이 필요한지. 어떤 TODO 항목이고, 어떤 PRD 요구사항에서 출발했는지. -->

## 변경 내용
<!-- 무엇을 구현하거나 변경했는지 요약. -->

## 주요 변경 파일
<!-- 변경된 파일마다 한 줄씩, [신규] / [수정] / [삭제] 표시 후 설명. -->
- `파일경로` [신규/수정/삭제] 설명

## 설계 의도
<!-- 핵심 결정과 그 이유. 다른 방법도 있었다면 왜 이 방향을 선택했는지. -->

## 결과 및 확인
<!-- uv run pytest 결과 붙여넣기. 테스트 없을 경우 이유 명시. -->

```
uv run pytest
```

## 워크로그 체크
- [ ] `docs/worklogs/YYYY-MM-DD_브랜치명.md` 추가 완료
- [ ] `TODO.md` 완료 항목 체크 업데이트 완료

## 관련 이슈
closes #이슈번호
