### PR TITLE
feat: LangGraph StateGraph 조립 및 조건부 라우팅 구현 (#T9)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -240,17 +240,17 @@ PRD 케이스 1·2가 처음부터 끝까지 작동하는 것.
 **담당 파일**: `app/services/graph.py`, `tests/test_graph.py`
 **의존**: T4, T5, T6, T7, T8 | **블로킹**: T10
 
-- [ ] `tests/test_graph.py` 작성 — 케이스 1: `use_case=talk, tp1` → TP1 노드 라우팅 검증
-- [ ] `tests/test_graph.py` 작성 — 케이스 1: `use_case=learning, tp4` → TP4 노드 라우팅 검증
-- [ ] `tests/test_graph.py` 작성 — 케이스 2: 동일 두 케이스
-- [ ] `tests/test_graph.py` 작성 — `tp2`, `tp3`, `tp5` 라우팅 검증
-- [ ] `tests/test_graph.py` 작성 — 잘못된 `touchpoint` 입력 예외 처리 검증
-- [ ] `graph.py` — `StateGraph(ChatState)` 정의 및 노드 6개 등록 (classify + tp1~tp5)
-- [ ] `graph.py` — `entry → classify` 항상 통과 설정
-- [ ] `graph.py` — `use_case + current_touchpoint` 기준 조건부 라우팅 함수
-- [ ] `graph.py` — `InMemorySaver` 연결 (thread_id 기반 세션 유지)
-- [ ] `graph.py` — 그래프 컴파일 및 `stream()` 인터페이스 노출
-- [ ] **완료 기준**: `uv run pytest tests/test_graph.py` 통과, 케이스 1·2 전체 흐름 수동 확인
+- [x] `tests/test_graph.py` 작성 — 케이스 1: `use_case=talk, tp1` → TP1 노드 라우팅 검증
+- [x] `tests/test_graph.py` 작성 — 케이스 1: `use_case=learning, tp4` → TP4 노드 라우팅 검증
+- [x] `tests/test_graph.py` 작성 — 케이스 2: 동일 두 케이스
+- [x] `tests/test_graph.py` 작성 — `tp2`, `tp3`, `tp5` 라우팅 검증
+- [x] `tests/test_graph.py` 작성 — 잘못된 `touchpoint` 입력 예외 처리 검증
+- [x] `graph.py` — `StateGraph(ChatState)` 정의 및 노드 6개 등록 (classify + tp1~tp5)
+- [x] `graph.py` — `entry → classify` 항상 통과 설정
+- [x] `graph.py` — `use_case + current_touchpoint` 기준 조건부 라우팅 함수
+- [x] `graph.py` — `InMemorySaver` 연결 (thread_id 기반 세션 유지)
+- [x] `graph.py` — 그래프 컴파일 및 `stream()` 인터페이스 노출
+- [x] **완료 기준**: `uv run pytest tests/test_graph.py` 통과, 케이스 1·2 전체 흐름 수동 확인
 
 ---
 

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Literal, TypedDict, Union
+from typing import Annotated, Literal, TypedDict, Union
 
 from pydantic import BaseModel, Field
 
@@ -19,9 +19,8 @@ from app.schemas.student import (
     WrongAnswerPattern,
 )
 
-if TYPE_CHECKING:
-    # langchain-core는 'uv add langgraph langchain-upstage langsmith' 이후 사용 가능
-    from langchain_core.messages import BaseMessage
+# LangGraph가 런타임에 get_type_hints()를 호출하므로 TYPE_CHECKING 블록 밖에서 import
+from langchain_core.messages import BaseMessage
 
 
 # ─── LangGraph State (TypedDict) ─────────────────────────────────────────────
@@ -62,6 +61,9 @@ class ChatState(TypedDict):
 
     # ─── 노드 라우팅용 ───
     current_touchpoint: Touchpoint
+
+    # ─── 노드 출력 ───
+    response: ChatResponse | None  # 각 TP 노드가 생성한 최종 응답
 
 
 # ─── API Request / Response (Pydantic) ───────────────────────────────────────

--- a/app/services/graph.py
+++ b/app/services/graph.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from app.core.enums import Touchpoint, UseCase
+from app.core.logging import get_logger
+from app.schemas.chat import ChatState
+from app.services.nodes.classify import classify
+from app.services.nodes.common import make_chat_response
+from app.services.nodes.tp1 import tp1
+from app.services.nodes.tp2 import tp2
+from app.services.nodes.tp3 import tp3
+from app.services.nodes.tp4 import tp4
+from app.services.nodes.tp5 import tp5
+
+logger = get_logger(__name__)
+
+# ─── LangGraph 노드 래퍼 ──────────────────────────────────────────────────────
+# TP 노드들은 ChatResponse 또는 dict를 반환하므로,
+# LangGraph state update dict 형식으로 통일한다.
+
+def _tp1_node(state: ChatState) -> dict:
+    return {"response": tp1(state)}
+
+
+def _tp2_node(state: ChatState) -> dict:
+    return {"response": tp2(state)}
+
+
+def _tp3_node(state: ChatState) -> dict:
+    return {"response": tp3(state)}
+
+
+def _tp4_node(state: ChatState) -> dict:
+    result = tp4(state)
+    messages = result["tp4_response"]
+    return {"response": make_chat_response(state["thread_id"], messages)}
+
+
+def _tp5_node(state: ChatState) -> dict:
+    return {"response": tp5(state)}
+
+
+# ─── 라우팅 함수 ──────────────────────────────────────────────────────────────
+
+def _route(state: ChatState) -> str:
+    use_case = state["use_case"]
+    touchpoint = state["current_touchpoint"]
+
+    if use_case == UseCase.LEARNING:
+        if touchpoint != Touchpoint.TP4:
+            raise ValueError(
+                f"use_case=learning은 tp4만 허용됩니다. 받은 값: {touchpoint}"
+            )
+        return "tp4"
+
+    talk_routes = {
+        Touchpoint.TP1: "tp1",
+        Touchpoint.TP2: "tp2",
+        Touchpoint.TP3: "tp3",
+        Touchpoint.TP5: "tp5",
+    }
+
+    if touchpoint not in talk_routes:
+        raise ValueError(
+            f"use_case=talk에서 지원하지 않는 touchpoint: {touchpoint}"
+        )
+
+    return talk_routes[touchpoint]
+
+
+# ─── 그래프 조립 ──────────────────────────────────────────────────────────────
+
+_builder = StateGraph(ChatState)
+
+_builder.add_node("classify", classify)
+_builder.add_node("tp1", _tp1_node)
+_builder.add_node("tp2", _tp2_node)
+_builder.add_node("tp3", _tp3_node)
+_builder.add_node("tp4", _tp4_node)
+_builder.add_node("tp5", _tp5_node)
+
+_builder.add_edge(START, "classify")
+_builder.add_conditional_edges("classify", _route)
+
+for _tp_node in ("tp1", "tp2", "tp3", "tp4", "tp5"):
+    _builder.add_edge(_tp_node, END)
+
+memory = InMemorySaver()
+graph = _builder.compile(checkpointer=memory)

--- a/docs/worklogs/2026-04-28_TODO-T9.md
+++ b/docs/worklogs/2026-04-28_TODO-T9.md
@@ -1,0 +1,59 @@
+# 작업 로그 — T9 LangGraph StateGraph + 조건부 라우팅
+
+**날짜**: 2026-04-28
+**브랜치**: TODO/T9
+**담당**: T9
+
+---
+
+## 배경
+
+T4~T8 완료 후 모든 노드를 하나의 LangGraph StateGraph로 조립한다.
+classify → 조건부 라우팅 → TP 노드 흐름을 구현하고 InMemorySaver로 세션을 유지한다.
+
+---
+
+## 구현 내용
+
+### `app/schemas/chat.py` 수정
+- `ChatState`에 `response: ChatResponse | None` 필드 추가
+  — 각 TP 노드가 생성한 최종 응답을 state에 저장
+- `BaseMessage` import를 `TYPE_CHECKING` 블록 밖으로 이동
+  — LangGraph가 런타임에 `get_type_hints()`를 호출하므로 필수
+
+### `app/services/graph.py` 신규
+- 노드 래퍼 함수 5개 (`_tp1_node` ~ `_tp5_node`)
+  — tp1/tp2/tp3/tp5: `ChatResponse` → `{"response": ...}` 변환
+  — tp4: `{"tp4_response": messages}` → `{"response": make_chat_response(...)}` 변환
+- `_route(state)`: `use_case + current_touchpoint` 기준 라우팅
+  — `LEARNING + TP4` → tp4
+  — `TALK + TP1/2/3/5` → 각 TP 노드
+  — 그 외 조합은 `ValueError`
+- `StateGraph(ChatState)` 노드 6개 등록, `START → classify → 조건부 → TP → END`
+- `InMemorySaver` 연결, `graph.compile()` 후 모듈 레벨 export
+
+### `tests/test_graph.py` 신규
+- 케이스 1·2 × TALK/LEARNING 라우팅 검증 (4개)
+- TP2·TP3·TP5 라우팅 검증 (3개)
+- 잘못된 조합 예외 처리 검증 (2개): `LEARNING+TP1`, `TALK+TP4`
+
+---
+
+## 테스트 결과
+
+```
+uv run pytest tests/test_graph.py -v
+9 passed in 0.47s
+
+uv run pytest (전체)
+120 passed in 2.83s
+```
+
+---
+
+## 특이사항
+
+- `BaseMessage`를 `TYPE_CHECKING` 밖으로 옮기는 것은 LangGraph 1.1.9의 요구사항
+  — 기존 TP 노드 테스트에는 영향 없음 (런타임에 실제 import가 이루어지는 것이 올바른 동작)
+- tp4의 반환 타입(`dict[str, list[ResponseMessage]]`)이 다른 TP 노드(`ChatResponse`)와 달라
+  래퍼 함수에서 통일 처리 — T10 API 연결 시 response 필드에서 일관되게 꺼낼 수 있음

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.enums import GradeGroup, Segment, Touchpoint, UseCase
+from app.data.loader import StudentRecord
+from app.services.graph import graph
+
+
+def _invoke(student: StudentRecord, use_case: UseCase, touchpoint: Touchpoint) -> dict:
+    """그래프를 invoke하고 최종 state를 반환한다."""
+    config = {"configurable": {"thread_id": f"test-{student['student_id']}-{touchpoint}"}}
+    initial = {
+        "thread_id": f"test-{student['student_id']}-{touchpoint}",
+        "student_id": student["student_id"],
+        "use_case": use_case,
+        "current_touchpoint": touchpoint,
+        "response": None,
+    }
+    with patch("app.services.nodes.classify.load_student", return_value=student):
+        return graph.invoke(initial, config=config)
+
+
+# ─── 케이스 1 라우팅 ──────────────────────────────────────────────────────────
+
+def test_case1_talk_tp1_routes_to_tp1(case1_student, mock_llm):
+    result = _invoke(case1_student, UseCase.TALK, Touchpoint.TP1)
+    assert result["response"] is not None
+    types = [m.type for m in result["response"].messages]
+    assert "text" in types
+    assert "choices" in types
+
+
+def test_case1_learning_tp4_routes_to_tp4(case1_student, mock_llm):
+    result = _invoke(case1_student, UseCase.LEARNING, Touchpoint.TP4)
+    assert result["response"] is not None
+
+
+# ─── 케이스 2 라우팅 ──────────────────────────────────────────────────────────
+
+def test_case2_talk_tp1_routes_to_tp1(case2_student, mock_llm):
+    result = _invoke(case2_student, UseCase.TALK, Touchpoint.TP1)
+    assert result["response"] is not None
+    types = [m.type for m in result["response"].messages]
+    assert "text" in types
+    assert "choices" in types
+
+
+def test_case2_learning_tp4_routes_to_tp4(case2_student, mock_llm):
+    result = _invoke(case2_student, UseCase.LEARNING, Touchpoint.TP4)
+    assert result["response"] is not None
+
+
+# ─── 보조 터치포인트 라우팅 ───────────────────────────────────────────────────
+
+def test_tp2_routing(case1_student, mock_llm):
+    result = _invoke(case1_student, UseCase.TALK, Touchpoint.TP2)
+    assert result["response"] is not None
+
+
+def test_tp3_routing(case1_student, mock_llm):
+    result = _invoke(case1_student, UseCase.TALK, Touchpoint.TP3)
+    assert result["response"] is not None
+
+
+def test_tp5_routing(case1_student, mock_llm):
+    result = _invoke(case1_student, UseCase.TALK, Touchpoint.TP5)
+    assert result["response"] is not None
+
+
+# ─── 잘못된 입력 예외 처리 ────────────────────────────────────────────────────
+
+def test_invalid_touchpoint_learning_with_tp1_raises(case1_student, mock_llm):
+    with pytest.raises(Exception):
+        _invoke(case1_student, UseCase.LEARNING, Touchpoint.TP1)
+
+
+def test_invalid_touchpoint_talk_with_tp4_raises(case1_student, mock_llm):
+    with pytest.raises(Exception):
+        _invoke(case1_student, UseCase.TALK, Touchpoint.TP4)


### PR DESCRIPTION
모든 노드를 StateGraph로 조립하고 use_case+touchpoint 기준 라우팅을 연결한다. InMemorySaver로 thread_id 기반 세션을 유지하고 graph.invoke/stream 인터페이스를 노출한다.

- app/services/graph.py: StateGraph 노드 6개 등록, 조건부 라우팅, InMemorySaver
- app/schemas/chat.py: ChatState에 response 필드 추가, BaseMessage 런타임 import로 변경
- tests/test_graph.py: 케이스 1·2 라우팅, 보조 TP, 잘못된 입력 예외 검증 (9 passed)
- TODO.md: T9 완료 체크박스 업데이트
- docs/worklogs/2026-04-28_TODO-T9.md: 작업 로그 추가

## 배경 및 목적
<!-- 왜 이 PR이 필요한지. 어떤 TODO 항목이고, 어떤 PRD 요구사항에서 출발했는지. -->

## 변경 내용
<!-- 무엇을 구현하거나 변경했는지 요약. -->

## 주요 변경 파일
<!-- 변경된 파일마다 한 줄씩, [신규] / [수정] / [삭제] 표시 후 설명. -->
- `파일경로` [신규/수정/삭제] 설명

## 설계 의도
<!-- 핵심 결정과 그 이유. 다른 방법도 있었다면 왜 이 방향을 선택했는지. -->

## 결과 및 확인
<!-- uv run pytest 결과 붙여넣기. 테스트 없을 경우 이유 명시. -->

```
uv run pytest
```

## 워크로그 체크
- [ ] `docs/worklogs/YYYY-MM-DD_브랜치명.md` 추가 완료
- [ ] `TODO.md` 완료 항목 체크 업데이트 완료

## 관련 이슈
closes #이슈번호
