### PR TITLE
fix: classify 노드를 세션 첫 턴에만 실행하도록 수정

### DIFF
--- a/app/services/graph.py
+++ b/app/services/graph.py
@@ -70,6 +70,15 @@ def _route(state: ChatState) -> str:
     return talk_routes[touchpoint]
 
 
+# ─── 진입 라우팅 ─────────────────────────────────────────────────────────────
+
+def _entry_route(state: ChatState) -> str:
+    """첫 턴(student_profile 없음)이면 classify, 이후 턴이면 바로 TP 노드로."""
+    if state.get("student_profile") is None:
+        return "classify"
+    return _route(state)
+
+
 # ─── 그래프 조립 ──────────────────────────────────────────────────────────────
 
 _builder = StateGraph(ChatState)
@@ -81,11 +90,10 @@ _builder.add_node("tp3", _tp3_node)
 _builder.add_node("tp4", _tp4_node)
 _builder.add_node("tp5", _tp5_node)
 
-_builder.add_edge(START, "classify")
+# 첫 턴: START → classify → _route → TP 노드
+# 이후 턴: START → _route(state) → TP 노드 (classify 생략)
+_builder.add_conditional_edges(START, _entry_route)
 _builder.add_conditional_edges("classify", _route)
-
-for _tp_node in ("tp1", "tp2", "tp3", "tp4", "tp5"):
-    _builder.add_edge(_tp_node, END)
 
 memory = InMemorySaver()
 graph = _builder.compile(checkpointer=memory)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import uuid
 from unittest.mock import patch
 
 import pytest
+from langchain_core.messages import HumanMessage
 
 from app.core.enums import GradeGroup, Segment, Touchpoint, UseCase
 from app.data.loader import StudentRecord
@@ -80,3 +82,63 @@ def test_invalid_touchpoint_learning_with_tp1_raises(case1_student, mock_llm):
 def test_invalid_touchpoint_talk_with_tp4_raises(case1_student, mock_llm):
     with pytest.raises(Exception):
         _invoke(case1_student, UseCase.TALK, Touchpoint.TP4)
+
+
+# ─── 세션 지속성 — classify는 첫 턴에만 실행 ─────────────────────────────────
+
+def test_classify_runs_only_on_first_turn(case1_student, mock_llm):
+    """같은 thread_id로 2번 호출하면 classify(load_student)는 1번만 실행된다."""
+    thread_id = f"session-test-{uuid.uuid4()}"
+    config = {"configurable": {"thread_id": thread_id}}
+
+    initial = {
+        "thread_id": thread_id,
+        "student_id": case1_student["student_id"],
+        "use_case": UseCase.TALK,
+        "current_touchpoint": Touchpoint.TP1,
+        "response": None,
+    }
+
+    with patch("app.services.nodes.classify.load_student", return_value=case1_student) as mock_load:
+        # 턴 1
+        graph.invoke(initial, config=config)
+        assert mock_load.call_count == 1
+
+        # 턴 2 — 같은 thread_id, chat_history에 사용자 입력 추가
+        turn2 = {
+            "use_case": UseCase.LEARNING,
+            "current_touchpoint": Touchpoint.TP4,
+            "chat_history": [HumanMessage(content="too_long")],
+        }
+        graph.invoke(turn2, config=config)
+        # classify(load_student)는 여전히 1번만 호출됐어야 한다
+        assert mock_load.call_count == 1
+
+
+def test_chat_history_preserved_on_second_turn(case1_student, mock_llm):
+    """턴 2에서 chat_history가 classify에 의해 초기화되지 않는다."""
+    thread_id = f"session-history-{uuid.uuid4()}"
+    config = {"configurable": {"thread_id": thread_id}}
+
+    initial = {
+        "thread_id": thread_id,
+        "student_id": case1_student["student_id"],
+        "use_case": UseCase.TALK,
+        "current_touchpoint": Touchpoint.TP1,
+        "response": None,
+    }
+
+    with patch("app.services.nodes.classify.load_student", return_value=case1_student):
+        graph.invoke(initial, config=config)
+
+        turn2 = {
+            "use_case": UseCase.LEARNING,
+            "current_touchpoint": Touchpoint.TP4,
+            "chat_history": [HumanMessage(content="too_long")],
+        }
+        result = graph.invoke(turn2, config=config)
+
+    # chat_history가 보존되어 있어야 한다
+    history = result["chat_history"]
+    contents = [m.content for m in history]
+    assert "too_long" in contents


### PR DESCRIPTION


## 요약                                                                                                                                                                                                 
                                                                                                                                                                                                        
  - classify 노드가 매 요청마다 실행되어 `chat_history`를 `[]`로 초기화하는 버그 수정                                                                                                                     
  - TP4 다중 턴 흐름(1턴: 원인 선택지 제공 → 2턴: 원인 감지 후 코칭)이 동작하지 않는 문제의 근본 원인
                                                                                                                                                                                                          
  ## 변경 내용                                              

  `graph.py`에 `_entry_route()` 함수를 추가해 진입 라우팅을 수정했습니다.

  - **첫 턴** (`student_profile`이 없는 경우): `START → classify → TP 노드`
  - **이후 턴** (`student_profile`이 이미 state에 있는 경우): `START → TP 노드` (classify 생략)

  classify는 학생 데이터를 로드하고 세그먼트·학년 그룹을 세팅하는 **세션 초기화 노드**이므로, 같은 `thread_id` 세션 내에서는 최초 1회만 실행되어야 합니다. InMemorySaver가 이미 state를 체크포인트로
  보존하고 있으므로 이후 턴에서는 classify를 재실행할 필요가 없습니다.

  ## 테스트

  - `test_classify_runs_only_on_first_turn`: 같은 `thread_id`로 2회 호출 시 `load_student`가 1번만 실행됨을 검증
  - `test_chat_history_preserved_on_second_turn`: 2턴에서 `chat_history`가 초기화되지 않고 보존됨을 검증
  - 전체 테스트 128개 통과