### PR TITLE
fix: build_expression 힌트 단계를 LLM 생성으로 전환, 하드코딩 제거

### DIFF
--- a/app/services/nodes/tp4.py
+++ b/app/services/nodes/tp4.py
@@ -110,6 +110,49 @@ def _invoke_llm(system_prompt: str, cause: str) -> str:
     return response.content
 
 
+_HINT_FALLBACK = [
+    "문제에서 전체(기준)가 되는 양을 찾아요.",
+    "비교하는 양이 전체 중 얼마인지 확인해요.",
+    "비율 = 비교하는 양 ÷ 기준량 식을 써요.",
+]
+
+
+def _generate_hint_steps(state: ChatState) -> list[str]:
+    """현재 태스크 맥락을 LLM에 전달해 단계별 힌트를 생성한다.
+
+    LLM 응답이 2줄 미만이거나 오류가 발생하면 _HINT_FALLBACK으로 대체한다.
+    """
+    from app.clients.upstage import llm
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    current_task = state.get("current_task")
+    task_line = (
+        f"과목: {current_task['subject']}, 단원: {current_task['unit']}"
+        if current_task
+        else "수학 식 세우기"
+    )
+
+    system = _build_system_prompt(state["segment"], state["grade_group"], "build_expression")
+    user = (
+        f"{task_line}\n"
+        "이 단원에서 식을 세우는 방법을 3~4단계로 나눠줘. "
+        "각 단계는 한 문장으로, 번호 없이 줄바꿈으로 구분해."
+    )
+
+    try:
+        response = llm.invoke([SystemMessage(content=system), HumanMessage(content=user)])
+        steps = [s.strip() for s in response.content.splitlines() if s.strip()]
+        if len(steps) >= 2:
+            return steps
+    except Exception:
+        logger.warning(
+            "hint step LLM 생성 실패, fallback 사용",
+            extra={"task": task_line},
+        )
+
+    return _HINT_FALLBACK
+
+
 def _assemble_messages(cause: str, llm_text: str, state: ChatState) -> list[ResponseMessage]:
     """원인별로 고정된 메시지 타입 구조에 LLM 텍스트를 채운다."""
 
@@ -150,12 +193,8 @@ def _assemble_messages(cause: str, llm_text: str, state: ChatState) -> list[Resp
         return [make_text(llm_text)]
 
     if cause == "build_expression":
-        # 식 세우기 막힘 → TextMessage + HintCardMessage
-        hint_steps = [
-            "무엇을 전체(기준)로 볼지 먼저 정해요.",
-            "비교하는 양이 전체 중 얼마인지 찾아요.",
-            "비율 = 비교하는 양 ÷ 기준량 식을 써요.",
-        ]
+        # 식 세우기 막힘 → TextMessage + HintCardMessage (단계는 LLM 생성, 실패 시 fallback)
+        hint_steps = _generate_hint_steps(state)
         return [make_text(llm_text), make_hint_card(hint_steps)]
 
     if cause == "check_calculation":

--- a/tests/test_tp4.py
+++ b/tests/test_tp4.py
@@ -149,6 +149,7 @@ class TestTp4Case2Math:
     def test_build_expression_hint_card_has_steps(
         self, make_chat_state, case2_student, mock_llm
     ):
+        # mock_llm은 단일 줄 응답 → fallback 힌트 사용 → 2개 이상 보장
         state = self._make_state(make_chat_state, case2_student, "build_expression")
         result = tp4(state)
         messages = result["tp4_response"]
@@ -156,6 +157,41 @@ class TestTp4Case2Math:
         hint_cards = [m for m in messages if isinstance(m, HintCardMessage)]
         assert hint_cards, "HintCardMessage가 없음"
         assert len(hint_cards[0].steps) >= 2, "힌트 단계가 2개 이상이어야 함"
+
+    def test_build_expression_uses_llm_steps_when_multiline(
+        self, make_chat_state, case2_student, monkeypatch
+    ):
+        # LLM이 다중 줄을 반환하면 그 내용이 힌트 단계로 사용된다
+        import sys
+        import types
+
+        from tests.conftest import FakeLLM
+
+        multiline_llm = FakeLLM(response_content="기준량을 확인해요.\n비교량을 찾아요.\n식을 써요.")
+        fake_mod = types.ModuleType("app.clients.upstage")
+        fake_mod.llm = multiline_llm
+        monkeypatch.setitem(sys.modules, "app.clients.upstage", fake_mod)
+
+        state = self._make_state(make_chat_state, case2_student, "build_expression")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        hint_cards = [m for m in messages if isinstance(m, HintCardMessage)]
+        assert hint_cards, "HintCardMessage가 없음"
+        step_contents = [s.content for s in hint_cards[0].steps]
+        assert "기준량을 확인해요." in step_contents
+
+    def test_build_expression_fallback_when_llm_singleline(
+        self, make_chat_state, case2_student, mock_llm
+    ):
+        # LLM이 단일 줄을 반환하면 fallback 힌트가 적용된다
+        state = self._make_state(make_chat_state, case2_student, "build_expression")
+        result = tp4(state)
+        messages = result["tp4_response"]
+
+        hint_cards = [m for m in messages if isinstance(m, HintCardMessage)]
+        # fallback은 _HINT_FALLBACK 3개 항목
+        assert len(hint_cards[0].steps) == 3
 
 
 # ─── 세그먼트명 노출 방지 ─────────────────────────────────────────────────────


### PR DESCRIPTION
기존에는 식 세우기 막힘 원인의 hint_steps가 비율 단원 고정 3줄로 하드코딩되어
어떤 단원·문제가 들어와도 동일한 답을 반환하는 문제가 있었습니다.

변경 내용:
- _generate_hint_steps(state) 추가
  - 현재 태스크의 과목·단원을 LLM에 전달해 단계별 힌트를 생성
  - 응답이 2줄 미만이거나 예외 발생 시 _HINT_FALLBACK(일반 식 세우기 3단계)으로 대체
- _assemble_messages의 build_expression 케이스를 _generate_hint_steps 호출로 교체
- 테스트 2개 추가
  - LLM 다중 줄 응답 → 해당 내용이 힌트 단계로 사용됨
  - LLM 단일 줄 응답 → fallback 3단계로 대체됨

## 배경 및 목적
<!-- 왜 이 PR이 필요한지. 어떤 TODO 항목이고, 어떤 PRD 요구사항에서 출발했는지. -->

## 변경 내용
<!-- 무엇을 구현하거나 변경했는지 요약. -->

## 주요 변경 파일
<!-- 변경된 파일마다 한 줄씩, [신규] / [수정] / [삭제] 표시 후 설명. -->
- `파일경로` [신규/수정/삭제] 설명

## 설계 의도
<!-- 핵심 결정과 그 이유. 다른 방법도 있었다면 왜 이 방향을 선택했는지. -->

## 결과 및 확인
<!-- uv run pytest 결과 붙여넣기. 테스트 없을 경우 이유 명시. -->

```
uv run pytest
```

## 워크로그 체크
- [ ] `docs/worklogs/YYYY-MM-DD_브랜치명.md` 추가 완료
- [ ] `TODO.md` 완료 항목 체크 업데이트 완료

## 관련 이슈
closes #이슈번호
