### PR TITLE
fix: 시연 케이스 데이터와 러너 기대값 정렬

### DIFF
--- a/app/data/mock_students.json
+++ b/app/data/mock_students.json
@@ -142,15 +142,15 @@
   {
     "student_id": "lower-high-lazy",
     "profile": {
-      "name": "도윤",
+      "name": "성준",
       "grade": 2,
-      "preferred_subject": "수학",
-      "strong_subject": "수학",
+      "preferred_subject": "국어",
+      "strong_subject": "국어",
       "recent_avg_score": 94,
       "avg_completion_rate": 42
     },
     "learning_history": {
-      "subject_avg_scores": {"국어": 88, "수학": 94, "영어": 90, "통합": 91},
+      "subject_avg_scores": {"국어": 94, "수학": 88, "영어": 90, "통합": 91},
       "subject_completion_rates": {"국어": 45, "수학": 42, "영어": 44, "통합": 48}
     },
     "learning_pattern": {
@@ -162,11 +162,31 @@
       "careless_habit": true
     },
     "wrong_answer_pattern": {
-      "frequent_wrong_type": "받아올림 계산",
-      "repeated_wrong_subjects": ["수학"],
+      "frequent_wrong_type": "중심 문장 찾기",
+      "repeated_wrong_subjects": ["국어"],
       "wrong_cause": "실수"
     },
     "today_tasks": [
+      {
+        "subject": "국어",
+        "unit": "문단의 짜임 - 긴글 이해하기",
+        "problem_ids": ["lower_korean_paragraph_001"],
+        "problem_id": "lower_korean_paragraph_001",
+        "problem_count": 1,
+        "estimated_time": 5,
+        "difficulty": "중",
+        "ai_predicted_score": 94
+      },
+      {
+        "subject": "국어",
+        "unit": "문단의 짜임 - 중심 문장과 뒷받침 문장 찾기",
+        "problem_ids": ["lower_korean_paragraph_002"],
+        "problem_id": "lower_korean_paragraph_002",
+        "problem_count": 1,
+        "estimated_time": 5,
+        "difficulty": "상",
+        "ai_predicted_score": 88
+      },
       {
         "subject": "수학",
         "unit": "한 자리 수 더하기",
@@ -175,27 +195,7 @@
         "problem_count": 5,
         "estimated_time": 8,
         "difficulty": "중",
-        "ai_predicted_score": 93
-      },
-      {
-        "subject": "국어",
-        "unit": "받침이 있는 낱말 읽기",
-        "problem_ids": ["lower_korean_reading_001"],
-        "problem_id": "lower_korean_reading_001",
-        "problem_count": 5,
-        "estimated_time": 10,
-        "difficulty": "하",
         "ai_predicted_score": 88
-      },
-      {
-        "subject": "통합",
-        "unit": "봄 관찰하기",
-        "problem_ids": ["lower_integrated_season_001"],
-        "problem_id": "lower_integrated_season_001",
-        "problem_count": 4,
-        "estimated_time": 8,
-        "difficulty": "하",
-        "ai_predicted_score": 91
       },
       {
         "subject": "영어",
@@ -652,20 +652,30 @@
       "careless_habit": false
     },
     "wrong_answer_pattern": {
-      "frequent_wrong_type": "비율과 비례식",
+      "frequent_wrong_type": "비와 비율",
       "repeated_wrong_subjects": ["수학"],
       "wrong_cause": "개념 부족"
     },
     "today_tasks": [
       {
         "subject": "수학",
-        "unit": "비율과 비례식",
+        "unit": "비와 비율",
         "problem_ids": ["math_ratio_saltwater_001"],
         "problem_id": "math_ratio_saltwater_001",
         "problem_count": 4,
         "estimated_time": 15,
         "difficulty": "중",
         "ai_predicted_score": 73
+      },
+      {
+        "subject": "국어",
+        "unit": "정보와 표현 판단하기",
+        "problem_ids": ["upper_korean_argument_001"],
+        "problem_id": "upper_korean_argument_001",
+        "problem_count": 5,
+        "estimated_time": 12,
+        "difficulty": "중",
+        "ai_predicted_score": 76
       },
       {
         "subject": "과학",
@@ -676,16 +686,6 @@
         "estimated_time": 12,
         "difficulty": "중",
         "ai_predicted_score": 84
-      },
-      {
-        "subject": "국어",
-        "unit": "주장과 근거 파악하기",
-        "problem_ids": ["upper_korean_argument_001"],
-        "problem_id": "upper_korean_argument_001",
-        "problem_count": 5,
-        "estimated_time": 12,
-        "difficulty": "중",
-        "ai_predicted_score": 76
       },
       {
         "subject": "사회",

--- a/scripts/run_scenarios.py
+++ b/scripts/run_scenarios.py
@@ -85,6 +85,15 @@ DEFAULT_STUDENT_IDS = [
     "upper-low-diligent",
 ]
 
+DEMO_TP4_PROBLEM_IDS = {
+    "lower-high-lazy": "lower_korean_paragraph_002",
+    "upper-low-diligent": "math_ratio_saltwater_001",
+}
+
+DEMO_TP3_REMAINING_COUNTS = {
+    "lower-high-lazy": 1,
+}
+
 TP_SCENARIOS = [
     (UseCase.TALK, Touchpoint.TP1, 1, "", "TP1 home-screen entry"),
     (UseCase.TALK, Touchpoint.TP2, 1, "", "TP2 unit completed"),
@@ -110,8 +119,8 @@ TP4_SIMULATED_FOLLOWUPS = [
 
 TP4_SIMULATED_FOLLOWUPS_BY_SUBJECT = {
     "국어": [
-        "아직 어느 글자를 봐야 하는지 잘 모르겠어요.",
-        "그럼 글자 아래에 붙은 걸 먼저 보면 되나요?",
+        "아직 어느 문장을 봐야 하는지 잘 모르겠어요.",
+        "그럼 중심 문장과 어울리는지 먼저 보면 되나요?",
     ],
     "수학": [
         "아직 어떤 숫자를 써야 하는지 잘 모르겠어요.",
@@ -433,6 +442,11 @@ def _scenario_state_overrides(
         current_task = task or (today_tasks[0] if today_tasks else None)
 
     pattern = record["learning_pattern"]
+    remaining_count = (
+        DEMO_TP3_REMAINING_COUNTS.get(record["student_id"], 2)
+        if touchpoint == Touchpoint.TP3
+        else None
+    )
     return {
         "student_profile": record["profile"],
         "learning_history": record["learning_history"],
@@ -441,7 +455,7 @@ def _scenario_state_overrides(
         "today_tasks": today_tasks,
         "completed_tasks": completed_tasks,
         "current_task": current_task,
-        "current_task_remaining_count": 2 if touchpoint == Touchpoint.TP3 else None,
+        "current_task_remaining_count": remaining_count,
         "current_problem": None,
         "tp4_phase": "awaiting_problem",
         "tp4_turn_count": 0,
@@ -469,6 +483,11 @@ def _select_scenario_task(record: StudentRecord, touchpoint: Touchpoint) -> Task
         return {}
 
     if touchpoint == Touchpoint.TP4:
+        target_problem_id = DEMO_TP4_PROBLEM_IDS.get(record["student_id"])
+        if target_problem_id:
+            for task in tasks:
+                if target_problem_id in _task_problem_ids(task):
+                    return task
         for task in tasks:
             if _task_problem_ids(task):
                 return task

--- a/tests/test_mock_student_matrix.py
+++ b/tests/test_mock_student_matrix.py
@@ -122,8 +122,8 @@ def test_runner_tp4_problem_selection_reads_from_problem_ids() -> None:
     student = load_student("lower-high-lazy")
     task = _select_scenario_task(student, Touchpoint.TP4)
 
-    assert _task_problem_id(task) == student["today_tasks"][0]["problem_ids"][0]
-    assert _task_problem_id(task) == "lower_korean_reading_001"
+    assert student["today_tasks"][0]["problem_ids"][0] == "lower_korean_paragraph_001"
+    assert _task_problem_id(task) == "lower_korean_paragraph_002"
 
 
 def test_focused_upper_case_still_uses_math_context() -> None:
@@ -137,16 +137,16 @@ def test_upper_case_tp2_state_moves_from_math_to_korean() -> None:
     student = load_student("upper-low-diligent")
     state = _scenario_state_overrides(student, Touchpoint.TP2, student["today_tasks"][0])
 
-    assert state["completed_tasks"][0]["unit"] == "비율과 비례식"
+    assert state["completed_tasks"][0]["unit"] == "비와 비율"
     assert state["current_task"]["subject"] == "국어"
-    assert state["current_task"]["unit"] == "주장과 근거 파악하기"
+    assert state["current_task"]["unit"] == "정보와 표현 판단하기"
 
 
-def test_tp3_state_has_two_remaining_current_task_problems() -> None:
+def test_tp3_state_has_one_remaining_current_task_problem_for_lower_demo() -> None:
     student = load_student("lower-high-lazy")
     state = _scenario_state_overrides(student, Touchpoint.TP3, student["today_tasks"][0])
 
-    assert state["current_task_remaining_count"] == 2
+    assert state["current_task_remaining_count"] == 1
 
 
 def test_tp5_state_marks_today_tasks_completed() -> None:
@@ -261,7 +261,7 @@ def test_runner_tp4_followup_matches_korean_reading_context() -> None:
     reply = _simulated_student_reply(Touchpoint.TP4, 3, task, fields)
 
     assert "숫자" not in reply
-    assert "글자" in reply
+    assert "문장" in reply
 
 
 def test_runner_main_writes_csv_and_transcript(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## 작업 내용

- PR #43 머지 후 남아 있던 시연 데이터 불일치를 정리했습니다.
- `lower-high-lazy`를 문서의 Case 1 의도대로 국어 우세/국어 2단계 시연 흐름으로 맞췄습니다.
  - TP1: `lower_korean_paragraph_001`
  - TP4: `lower_korean_paragraph_002`
- `upper-low-diligent`를 문서의 Case 2 의도대로 수학 `비와 비율` 완료 후 국어 `정보와 표현 판단하기`로 이어지게 맞췄습니다.
- 시나리오 러너가 데모 케이스별 TP4 대상 문제와 TP3 남은 문제 수를 올바르게 세팅하도록 보정했습니다.
- 변경된 시연 흐름에 맞춰 matrix 테스트 기대값을 갱신했습니다.

## 배경

PR #43과 #44가 머지된 뒤 관련 테스트를 돌렸을 때, `tests/test_mock_student_matrix.py`에서 3개 실패가 발생했습니다. 원인은 문서/expected_cases는 새 시연 흐름을 기준으로 바뀌었지만, `mock_students.json`과 시나리오 러너 일부 기대값이 옛 흐름에 남아 있었기 때문입니다.

## 검증

- `jq empty app/data/mock_students.json app/data/mock_problems.json scripts/scenarios/expected_cases.json`
- `uv run pytest tests/test_loader.py tests/test_mock_student_matrix.py tests/test_scenario_expectations.py tests/test_decision_policy.py`
- `uv run pytest tests/test_motivator_tp1.py tests/test_motivator_tp2.py tests/test_motivator_tp3.py tests/test_motivator_tp5.py tests/test_chat_api.py`
- `git diff --check`
